### PR TITLE
fix: Fix examples that cannot be compiled

### DIFF
--- a/.github/workflows/run-cl-arduino.yml
+++ b/.github/workflows/run-cl-arduino.yml
@@ -27,6 +27,17 @@ jobs:
       - name: Create a depend.list file
         run: |
           # eg: echo "<repo>" >> depend.list
+
+          echo Bodmer/JPEGDecoder >> depend.list
+          echo Bodmer/TJpg_Decoder >> depend.list
+          echo Bodmer/TFT_eFEX >> depend.list
+          echo Bodmer/TFT_eWidget >> depend.list
+          echo bitbank2/PNGdec >> depend.list
+          echo bitbank2/AnimatedGIF >> depend.list
+          echo tanakamasayuki/I2C_BM8563 >> depend.list
+          echo PaulStoffregen/Time >> depend.list
+          echo JChristensen/Timezone >> depend.list
+          echo Seeed-Studio/Seeed_Arduino_FS >> depend.list
  
 
 
@@ -36,91 +47,304 @@ jobs:
           # eg: echo "<path>,<fqbn>" >> ignore.list
 
           # xiao m0 RAM is too small
-          echo "320x240/All_Free_Fonts_Demo,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "320x240/Cellular_Automata,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "480x320/Cellular_Automata,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-
-          # xiao m0 RAM is too small
-          echo "320x240/All_Free_Fonts_Demo,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "320x240/Cellular_Automata,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "480x320/Cellular_Automata,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-
+          echo "320 x 240/All_Free_Fonts_Demo,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "320 x 240/Cellular_Automata,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "480 x 320/Cellular_Automata,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "PNG Images/Flash_PNG,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "PNG Images/Flash_transparent_PNG,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo " Round Display/Arduino_Life,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Round Display/GifPlayer ,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
 
 
-
-          # no Seeed_FS.h so can't compile
-          echo "SmoothFonts/Font_Demo_1,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "SmoothFonts/Font_Demo_1,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "SmoothFonts/Font_Demo_1,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "SmoothFonts/Font_Demo_1,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "SmoothFonts/Font_Demo_1,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "SmoothFonts/Font_Demo_1,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "SmoothFonts/Font_Demo_1,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "SmoothFonts/Font_Demo_1,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "SmoothFonts/Font_Demo_1,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-          echo "SmoothFonts/Font_Demo_2,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "SmoothFonts/Font_Demo_2,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "SmoothFonts/Font_Demo_2,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "SmoothFonts/Font_Demo_2,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "SmoothFonts/Font_Demo_2,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "SmoothFonts/Font_Demo_2,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "SmoothFonts/Font_Demo_2,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "SmoothFonts/Font_Demo_2,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "SmoothFonts/Font_Demo_2,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-          echo "SmoothFonts/Font_Demo_3,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "SmoothFonts/Font_Demo_3,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "SmoothFonts/Font_Demo_3,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "SmoothFonts/Font_Demo_3,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "SmoothFonts/Font_Demo_3,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "SmoothFonts/Font_Demo_3,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "SmoothFonts/Font_Demo_3,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "SmoothFonts/Font_Demo_3,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "SmoothFonts/Font_Demo_3,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-          echo "SmoothFonts/Font_Demo_4,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "SmoothFonts/Font_Demo_4,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "SmoothFonts/Font_Demo_4,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "SmoothFonts/Font_Demo_4,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "SmoothFonts/Font_Demo_4,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "SmoothFonts/Font_Demo_4,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "SmoothFonts/Font_Demo_4,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "SmoothFonts/Font_Demo_4,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "SmoothFonts/Font_Demo_4,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-          echo "SmoothFonts/Print_Smooth_Font,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "SmoothFonts/Print_Smooth_Font,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "SmoothFonts/Print_Smooth_Font,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "SmoothFonts/Print_Smooth_Font,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "SmoothFonts/Print_Smooth_Font,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "SmoothFonts/Print_Smooth_Font,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "SmoothFonts/Print_Smooth_Font,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "SmoothFonts/Print_Smooth_Font,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "SmoothFonts/Print_Smooth_Font,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-          echo "480x320/Touch_Controller_Demo,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "480x320/Touch_Controller_Demo,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "480x320/Touch_Controller_Demo,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "480x320/Touch_Controller_Demo,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "480x320/Touch_Controller_Demo,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "480x320/Touch_Controller_Demo,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "480x320/Touch_Controller_Demo,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "480x320/Touch_Controller_Demo,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "480x320/Touch_Controller_Demo,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-
-          echo "SmoothFonts/Unicode_test,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "SmoothFonts/Unicode_test,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "SmoothFonts/Unicode_test,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "SmoothFonts/Unicode_test,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "SmoothFonts/Unicode_test,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "SmoothFonts/Unicode_test,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "SmoothFonts/Unicode_test,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "SmoothFonts/Unicode_test,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "SmoothFonts/Unicode_test,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
+          # xiao ra4m1 RAM is too small
+          echo "320 x 240/All_Free_Fonts_Demo,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "320 x 240/Cellular_Automata,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "480 x 320/Cellular_Automata,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "PNG Images/Flash_PNG,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "PNG Images/Flash_transparent_PNG,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "Round Display/Arduino_Life,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "Round Display/GifPlayer ,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
           
+
+          # no SPIFFS so can't compile
+          echo "Smooth Fonts/SPIFFS/Font_Demo_1,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Font_Demo_1,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Font_Demo_1,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Font_Demo_1,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Smooth Fonts/SPIFFS/Font_Demo_2,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Font_Demo_2,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Font_Demo_2,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Font_Demo_2,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Smooth Fonts/SPIFFS/Font_Demo_3,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Font_Demo_3,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Font_Demo_3,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Font_Demo_3,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Smooth Fonts/SPIFFS/Font_Demo_4,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Font_Demo_4,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Font_Demo_4,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Font_Demo_4,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Smooth Fonts/SPIFFS/Print_Smooth_Font,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Print_Smooth_Font,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Print_Smooth_Font,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Print_Smooth_Font,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Smooth Fonts/SPIFFS/Smooth_font_gradient,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Smooth_font_gradient,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Smooth_font_gradient,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Smooth_font_gradient,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Smooth Fonts/SPIFFS/Smooth_font_reading_TFT,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Smooth_font_reading_TFT,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Smooth_font_reading_TFT,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Smooth_font_reading_TFT,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Smooth Fonts/SPIFFS/Unicode_test,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Unicode_test,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Unicode_test,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/SPIFFS/Unicode_test,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          
+          echo "Generic/TFT_SPIFFS_BMP,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Generic/TFT_SPIFFS_BMP,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Generic/TFT_SPIFFS_BMP,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Generic/TFT_SPIFFS_BMP,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+
+          echo "Sprite/Rotated_Sprite_3,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Sprite/Rotated_Sprite_3,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Sprite/Rotated_Sprite_3,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Sprite/Rotated_Sprite_3,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+
+
+          # no LittleFS.h so can't compile
+          echo "Smooth Fonts/FLASH_Array/Print_Smooth_Font,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/FLASH_Array/Print_Smooth_Font,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/FLASH_Array/Print_Smooth_Font,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/FLASH_Array/Print_Smooth_Font,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+
+          echo "Smooth Fonts/LittleFS/Font_Demo_1,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Font_Demo_1,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Font_Demo_1,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Font_Demo_1,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Smooth Fonts/LittleFS/Font_Demo_2,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Font_Demo_2,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Font_Demo_2,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Font_Demo_2,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Smooth Fonts/LittleFS/Font_Demo_3,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Font_Demo_3,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Font_Demo_3,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Font_Demo_3,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Smooth Fonts/LittleFS/Font_Demo_4,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Font_Demo_4,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Font_Demo_4,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Font_Demo_4,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Smooth Fonts/LittleFS/Print_Smooth_Font,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Print_Smooth_Font,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Print_Smooth_Font,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Print_Smooth_Font,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Smooth Fonts/LittleFS/Smooth_font_gradient,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Smooth_font_gradient,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Smooth_font_gradient,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Smooth_font_gradient,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Smooth Fonts/LittleFS/Smooth_font_reading_TFT,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Smooth_font_reading_TFT,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Smooth_font_reading_TFT,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Smooth_font_reading_TFT,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Smooth Fonts/LittleFS/Unicode_test,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Unicode_test,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Unicode_test,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/LittleFS/Unicode_test,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+
+          echo "PNG Images/LittleFS_PNG,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "PNG Images/LittleFS_PNG,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "PNG Images/LittleFS_PNG,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "PNG Images/LittleFS_PNG,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+
+          echo "PNG Images/LittleFS_PNG_DMA ,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "PNG Images/LittleFS_PNG_DMA ,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "PNG Images/LittleFS_PNG_DMA ,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "PNG Images/LittleFS_PNG_DMA ,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+
+  
+          # TJpg_Decoder library need SD.h so can't compile
+          echo "Sprite/Animated_dial,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Sprite/Animated_dial,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Sprite/Animated_dial,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Sprite/Animated_dial,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          
+          echo "160 x 128/TFT_flash_jpg,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "160 x 128/TFT_flash_jpg,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "160 x 128/TFT_flash_jpg,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "160 x 128/TFT_flash_jpg,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+
+          echo "480 x 320/TFT_flash_jpg ,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "480 x 320/TFT_flash_jpg ,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "480 x 320/TFT_flash_jpg ,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "480 x 320/TFT_flash_jpg ,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+         
+          echo "Round Display/TFT_flash_jpg ,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Round Display/TFT_flash_jpg ,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Round Display/TFT_flash_jpg ,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Round Display/TFT_flash_jpg ,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+    
+          
+          # TFT_eSPI miss function pushPixelsDMA and initDMA in seeed_XIAO_m0 xiaonRF52840 XIAO_RA4M1 so can't compile
+          echo "DMA test/boing_ball,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "DMA test/boing_ball,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "DMA test/boing_ball,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "DMA test/boing_ball,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          
+          echo "DMA test/Bouncy_Circles,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "DMA test/Bouncy_Circles,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "DMA test/Bouncy_Circles,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "DMA test/Bouncy_Circles,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          
+          echo "DMA test/Flash_Jpg_DMA,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "DMA test/Flash_Jpg_DMA,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "DMA test/Flash_Jpg_DMA,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "DMA test/Flash_Jpg_DMA,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          
+          echo "DMA test/SpriteRotatingCube,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "DMA test/SpriteRotatingCube,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "DMA test/SpriteRotatingCube,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "DMA test/SpriteRotatingCube,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list          
+
+
+          # TFT_eFEX library has compatibility issues with ESP32 so can't compile
+          echo "Sprite/Rotated_Sprite_3,esp32:esp32:XIAO_ESP32C3" >> ignore.list
+          echo "Sprite/Rotated_Sprite_3,esp32:esp32:XIAO_ESP32C6" >> ignore.list
+          echo "Sprite/Rotated_Sprite_3,esp32:esp32:XIAO_ESP32S3" >> ignore.list
+
+
+          # AnimatedGIF has compatibility issues with rp2350 so can't compile
+          echo "Round Display/GifPlayer,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
+
+
+          # only ESP32 can compile
+          echo "Generic/ESP32_SDcard_jpeg,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Generic/ESP32_SDcard_jpeg,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Generic/ESP32_SDcard_jpeg,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Generic/ESP32_SDcard_jpeg,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "Generic/ESP32_SDcard_jpeg,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
+          echo "Generic/ESP32_SDcard_jpeg,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
+          
+          echo "Smooth Fonts/SD_Card/ESP32_Smooth_Font_SD ,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Fonts/SD_Card/ESP32_Smooth_Font_SD ,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Fonts/SD_Card/ESP32_Smooth_Font_SD ,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Fonts/SD_Card/ESP32_Smooth_Font_SD ,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "Smooth Fonts/SD_Card/ESP32_Smooth_Font_SD,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
+          echo "Smooth Fonts/SD_Card/ESP32_Smooth_Font_SD,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
+         
+          echo "Smooth Graphics/Anti-aliased_Clock,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Smooth Graphics/Anti-aliased_Clock,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Smooth Graphics/Anti-aliased_Clock,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Smooth Graphics/Anti-aliased_Clock,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "Smooth Graphics/Anti-aliased_Clock,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
+          echo "Smooth Graphics/Anti-aliased_Clock,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
+          
+
+
+          # function setTouch and calibrateTouch are not currently supported, so can't compile
+          echo "Generic/On_Off_Button,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Generic/On_Off_Button,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Generic/On_Off_Button,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Generic/On_Off_Button,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "Generic/On_Off_Button,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
+          echo "Generic/On_Off_Button,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
+          echo "Generic/On_Off_Button,esp32:esp32:XIAO_ESP32C3" >> ignore.list
+          echo "Generic/On_Off_Button,esp32:esp32:XIAO_ESP32C6" >> ignore.list
+          echo "Generic/On_Off_Button,esp32:esp32:XIAO_ESP32S3" >> ignore.list
+
+          echo "Generic/TFT_Button_Label_Datum,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Generic/TFT_Button_Label_Datum,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Generic/TFT_Button_Label_Datum,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Generic/TFT_Button_Label_Datum,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "Generic/TFT_Button_Label_Datum,Seeeduino:rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
+          echo "Generic/TFT_Button_Label_Datum,Seeeduino:rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
+          echo "Generic/TFT_Button_Label_Datum,esp32:esp32:XIAO_ESP32C3" >> ignore.list
+          echo "Generic/TFT_Button_Label_Datum,esp32:esp32:XIAO_ESP32C6" >> ignore.list
+          echo "Generic/TFT_Button_Label_Datum,esp32:esp32:XIAO_ESP32S3" >> ignore.list
+
+          echo "Generic/Touch_calibrate,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Generic/Touch_calibrate,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Generic/Touch_calibrate,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Generic/Touch_calibrate,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "Generic/Touch_calibrate,Seeeduino:rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
+          echo "Generic/Touch_calibrate,Seeeduino:rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
+          echo "Generic/Touch_calibrate,esp32:esp32:XIAO_ESP32C3" >> ignore.list
+          echo "Generic/Touch_calibrate,esp32:esp32:XIAO_ESP32C6" >> ignore.list
+          echo "Generic/Touch_calibrate,esp32:esp32:XIAO_ESP32S3" >> ignore.list
+
+          echo "320 x 240/Keypad_240x320,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "320 x 240/Keypad_240x320,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "320 x 240/Keypad_240x320,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "320 x 240/Keypad_240x320,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "320 x 240/Keypad_240x320,Seeeduino:rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
+          echo "320 x 240/Keypad_240x320,Seeeduino:rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
+          echo "320 x 240/Keypad_240x320,esp32:esp32:XIAO_ESP32C3" >> ignore.list
+          echo "320 x 240/Keypad_240x320,esp32:esp32:XIAO_ESP32C6" >> ignore.list
+          echo "320 x 240/Keypad_240x320,esp32:esp32:XIAO_ESP32S3" >> ignore.list
+
+          echo "480 x 320/Keypad_480x320,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "480 x 320/Keypad_480x320,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "480 x 320/Keypad_480x320,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "480 x 320/Keypad_480x320,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "480 x 320/Keypad_480x320,Seeeduino:rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
+          echo "480 x 320/Keypad_480x320,Seeeduino:rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
+          echo "480 x 320/Keypad_480x320,esp32:esp32:XIAO_ESP32C3" >> ignore.list
+          echo "480 x 320/Keypad_480x320,esp32:esp32:XIAO_ESP32C6" >> ignore.list
+          echo "480 x 320/Keypad_480x320,esp32:esp32:XIAO_ESP32S3" >> ignore.list
+
+          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
+          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
+          echo "GUI Widgets/Buttons/Button_demo,esp32:esp32:XIAO_ESP32C3" >> ignore.list
+          echo "GUI Widgets/Buttons/Button_demo,esp32:esp32:XIAO_ESP32C6" >> ignore.list
+          echo "GUI Widgets/Buttons/Button_demo,esp32:esp32:XIAO_ESP32S3" >> ignore.list
+
+          echo "GUI Widgets/Sliders/Slider_demo,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "GUI Widgets/Sliders/Slider_demo,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "GUI Widgets/Sliders/Slider_demo,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "GUI Widgets/Sliders/Slider_demo,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "GUI Widgets/Sliders/Slider_demo ,Seeeduino:rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
+          echo "GUI Widgets/Sliders/Slider_demo ,Seeeduino:rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
+          echo "GUI Widgets/Sliders/Slider_demo ,esp32:esp32:XIAO_ESP32C3" >> ignore.list
+          echo "GUI Widgets/Sliders/Slider_demo ,esp32:esp32:XIAO_ESP32C6" >> ignore.list
+          echo "GUI Widgets/Sliders/Slider_demo ,esp32:esp32:XIAO_ESP32S3" >> ignore.list
+
+          echo "480 x 320/Touch_Controller_Demo,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "480 x 320/Touch_Controller_Demo,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "480 x 320/Touch_Controller_Demo,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "480 x 320/Touch_Controller_Demo,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "480 x 320/Touch_Controller_Demo,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
+          echo "480 x 320/Touch_Controller_Demo,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
+          echo "480 x 320/Touch_Controller_Demo,esp32:esp32:XIAO_ESP32C3" >> ignore.list
+          echo "480 x 320/Touch_Controller_Demo,esp32:esp32:XIAO_ESP32C6" >> ignore.list
+          echo "480 x 320/Touch_Controller_Demo,esp32:esp32:XIAO_ESP32S3" >> ignore.list
+
+          # function getTouchRawZ are not currently supported, so can't compile
+          echo "Test and diagnostics/Test_Touch_Controller,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Test and diagnostics/Test_Touch_Controller,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Test and diagnostics/Test_Touch_Controller,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Test and diagnostics/Test_Touch_Controller,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "Test and diagnostics/Test_Touch_Controller,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
+          echo "Test and diagnostics/Test_Touch_Controller,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
+          echo "Test and diagnostics/Test_Touch_Controller,esp32:esp32:XIAO_ESP32C3" >> ignore.list
+          echo "Test and diagnostics/Test_Touch_Controller,esp32:esp32:XIAO_ESP32C6" >> ignore.list
+          echo "Test and diagnostics/Test_Touch_Controller,esp32:esp32:XIAO_ESP32S3" >> ignore.list
+
 
 
       - name: Build sketch
@@ -139,3 +363,4 @@ jobs:
         run: ./ci/tools/issue.sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          

--- a/.github/workflows/run-cl-arduino.yml
+++ b/.github/workflows/run-cl-arduino.yml
@@ -38,6 +38,7 @@ jobs:
           echo PaulStoffregen/Time >> depend.list
           echo JChristensen/Timezone >> depend.list
           echo Seeed-Studio/Seeed_Arduino_FS >> depend.list
+          echo arduino-libraries/SD >> depend.list
  
 
 
@@ -52,7 +53,7 @@ jobs:
           echo "480 x 320/Cellular_Automata,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
           echo "PNG Images/Flash_PNG,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
           echo "PNG Images/Flash_transparent_PNG,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo " Round Display/Arduino_Life,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Round Display/Arduino_Life,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
           echo "Round Display/GifPlayer ,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
 
 
@@ -117,6 +118,31 @@ jobs:
           echo "Sprite/Rotated_Sprite_3,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
           echo "Sprite/Rotated_Sprite_3,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
 
+          echo "Generic/On_Off_Button,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Generic/On_Off_Button,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Generic/On_Off_Button,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Generic/On_Off_Button,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+
+          echo "Generic/TFT_Button_Label_Datum,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "Generic/TFT_Button_Label_Datum,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "Generic/TFT_Button_Label_Datum,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "Generic/TFT_Button_Label_Datum,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+
+          echo "320 x 240/Keypad_240x320,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "320 x 240/Keypad_240x320,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "320 x 240/Keypad_240x320,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "320 x 240/Keypad_240x320,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+
+          echo "480 x 320/Keypad_480x320,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "480 x 320/Keypad_480x320,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "480 x 320/Keypad_480x320,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "480 x 320/Keypad_480x320,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+
+          echo "480 x 320/Touch_Controller_Demo,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "480 x 320/Touch_Controller_Demo,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "480 x 320/Touch_Controller_Demo,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
+          echo "480 x 320/Touch_Controller_Demo,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+
 
           # no LittleFS.h so can't compile
           echo "Smooth Fonts/FLASH_Array/Print_Smooth_Font,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
@@ -174,50 +200,15 @@ jobs:
           echo "PNG Images/LittleFS_PNG_DMA ,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
           echo "PNG Images/LittleFS_PNG_DMA ,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
 
-  
-          # TJpg_Decoder library need SD.h so can't compile
-          echo "Sprite/Animated_dial,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "Sprite/Animated_dial,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "Sprite/Animated_dial,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "Sprite/Animated_dial,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          
-          echo "160 x 128/TFT_flash_jpg,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "160 x 128/TFT_flash_jpg,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "160 x 128/TFT_flash_jpg,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "160 x 128/TFT_flash_jpg,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
 
-          echo "480 x 320/TFT_flash_jpg ,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "480 x 320/TFT_flash_jpg ,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "480 x 320/TFT_flash_jpg ,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "480 x 320/TFT_flash_jpg ,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-         
-          echo "Round Display/TFT_flash_jpg ,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "Round Display/TFT_flash_jpg ,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "Round Display/TFT_flash_jpg ,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "Round Display/TFT_flash_jpg ,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-    
-          
-          # TFT_eSPI miss function pushPixelsDMA and initDMA in seeed_XIAO_m0 xiaonRF52840 XIAO_RA4M1 so can't compile
-          echo "DMA test/boing_ball,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "DMA test/boing_ball,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "DMA test/boing_ball,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "DMA test/boing_ball,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          
-          echo "DMA test/Bouncy_Circles,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "DMA test/Bouncy_Circles,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "DMA test/Bouncy_Circles,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "DMA test/Bouncy_Circles,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          
-          echo "DMA test/Flash_Jpg_DMA,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "DMA test/Flash_Jpg_DMA,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "DMA test/Flash_Jpg_DMA,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "DMA test/Flash_Jpg_DMA,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          
-          echo "DMA test/SpriteRotatingCube,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "DMA test/SpriteRotatingCube,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "DMA test/SpriteRotatingCube,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "DMA test/SpriteRotatingCube,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list          
-
+          echo "GUI Widgets/Sliders/Slider_demo,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
+          echo "GUI Widgets/Sliders/Slider_demo,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
+          echo "GUI Widgets/Sliders/Slider_demo,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
+          echo "GUI Widgets/Sliders/Slider_demo,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
 
           # TFT_eFEX library has compatibility issues with ESP32 so can't compile
           echo "Sprite/Rotated_Sprite_3,esp32:esp32:XIAO_ESP32C3" >> ignore.list
@@ -251,101 +242,6 @@ jobs:
           echo "Smooth Graphics/Anti-aliased_Clock,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
           echo "Smooth Graphics/Anti-aliased_Clock,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
           
-
-
-          # function setTouch and calibrateTouch are not currently supported, so can't compile
-          echo "Generic/On_Off_Button,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "Generic/On_Off_Button,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "Generic/On_Off_Button,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "Generic/On_Off_Button,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "Generic/On_Off_Button,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "Generic/On_Off_Button,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "Generic/On_Off_Button,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "Generic/On_Off_Button,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "Generic/On_Off_Button,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-          echo "Generic/TFT_Button_Label_Datum,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "Generic/TFT_Button_Label_Datum,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "Generic/TFT_Button_Label_Datum,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "Generic/TFT_Button_Label_Datum,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "Generic/TFT_Button_Label_Datum,Seeeduino:rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "Generic/TFT_Button_Label_Datum,Seeeduino:rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "Generic/TFT_Button_Label_Datum,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "Generic/TFT_Button_Label_Datum,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "Generic/TFT_Button_Label_Datum,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-          echo "Generic/Touch_calibrate,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "Generic/Touch_calibrate,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "Generic/Touch_calibrate,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "Generic/Touch_calibrate,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "Generic/Touch_calibrate,Seeeduino:rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "Generic/Touch_calibrate,Seeeduino:rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "Generic/Touch_calibrate,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "Generic/Touch_calibrate,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "Generic/Touch_calibrate,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-          echo "320 x 240/Keypad_240x320,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "320 x 240/Keypad_240x320,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "320 x 240/Keypad_240x320,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "320 x 240/Keypad_240x320,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "320 x 240/Keypad_240x320,Seeeduino:rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "320 x 240/Keypad_240x320,Seeeduino:rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "320 x 240/Keypad_240x320,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "320 x 240/Keypad_240x320,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "320 x 240/Keypad_240x320,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-          echo "480 x 320/Keypad_480x320,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "480 x 320/Keypad_480x320,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "480 x 320/Keypad_480x320,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "480 x 320/Keypad_480x320,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "480 x 320/Keypad_480x320,Seeeduino:rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "480 x 320/Keypad_480x320,Seeeduino:rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "480 x 320/Keypad_480x320,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "480 x 320/Keypad_480x320,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "480 x 320/Keypad_480x320,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "GUI Widgets/Buttons/Button_demo,Seeeduino:rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "GUI Widgets/Buttons/Button_demo,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "GUI Widgets/Buttons/Button_demo,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "GUI Widgets/Buttons/Button_demo,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-          echo "GUI Widgets/Sliders/Slider_demo,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "GUI Widgets/Sliders/Slider_demo,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "GUI Widgets/Sliders/Slider_demo,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "GUI Widgets/Sliders/Slider_demo,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "GUI Widgets/Sliders/Slider_demo ,Seeeduino:rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "GUI Widgets/Sliders/Slider_demo ,Seeeduino:rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "GUI Widgets/Sliders/Slider_demo ,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "GUI Widgets/Sliders/Slider_demo ,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "GUI Widgets/Sliders/Slider_demo ,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-          echo "480 x 320/Touch_Controller_Demo,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "480 x 320/Touch_Controller_Demo,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "480 x 320/Touch_Controller_Demo,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "480 x 320/Touch_Controller_Demo,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "480 x 320/Touch_Controller_Demo,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "480 x 320/Touch_Controller_Demo,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "480 x 320/Touch_Controller_Demo,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "480 x 320/Touch_Controller_Demo,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "480 x 320/Touch_Controller_Demo,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-          # function getTouchRawZ are not currently supported, so can't compile
-          echo "Test and diagnostics/Test_Touch_Controller,Seeeduino:samd:seeed_XIAO_m0" >> ignore.list
-          echo "Test and diagnostics/Test_Touch_Controller,Seeeduino:nrf52:xiaonRF52840" >> ignore.list
-          echo "Test and diagnostics/Test_Touch_Controller,Seeeduino:nrf52:xiaonRF52840Sense" >> ignore.list
-          echo "Test and diagnostics/Test_Touch_Controller,Seeeduino:renesas_uno:XIAO_RA4M1" >> ignore.list
-          echo "Test and diagnostics/Test_Touch_Controller,rp2040:rp2040:seeed_xiao_rp2040" >> ignore.list
-          echo "Test and diagnostics/Test_Touch_Controller,rp2040:rp2040:seeed_xiao_rp2350" >> ignore.list
-          echo "Test and diagnostics/Test_Touch_Controller,esp32:esp32:XIAO_ESP32C3" >> ignore.list
-          echo "Test and diagnostics/Test_Touch_Controller,esp32:esp32:XIAO_ESP32C6" >> ignore.list
-          echo "Test and diagnostics/Test_Touch_Controller,esp32:esp32:XIAO_ESP32S3" >> ignore.list
-
-
 
       - name: Build sketch
         run: |

--- a/Extensions/EPaper.h
+++ b/Extensions/EPaper.h
@@ -1,5 +1,9 @@
 #include "TFT_eSPI.h"
 
+#ifdef GDEM075T7_DRIVER
+#include "TFT_Drivers/GDEM075T7_Defines.h"
+#endif
+
 class EPaper : public TFT_eSprite
 {
 public:

--- a/Processors/TFT_eSPI_Generic.h
+++ b/Processors/TFT_eSPI_Generic.h
@@ -32,8 +32,8 @@
 // If smooth fonts are enabled the filing system may need to be loaded
 #ifdef SMOOTH_FONT
   // Call up the filing system for the anti-aliased fonts
-  //#define FS_NO_GLOBALS
-  //#include <FS.h>
+  #define FS_NO_GLOBALS
+  #include <Seeed_Arduino_FS.h>
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/Processors/TFT_eSPI_MG24.cpp
+++ b/Processors/TFT_eSPI_MG24.cpp
@@ -1,0 +1,378 @@
+////////////////////////////////////////////////////
+//      TFT_eSPI XIAO_MG24 driver functions       //
+////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Global variables
+////////////////////////////////////////////////////////////////////////////////////////
+// Select the SPI port to use
+#ifdef TFT_SPI_PORT
+SilabsSPI& spi = TFT_SPI_PORT;
+#else
+SilabsSPI& spi = SPI;
+#endif
+
+#if defined (TFT_SDA_READ) && !defined (TFT_PARALLEL_8_BIT)
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           tft_Read_8
+** Description:             Bit bashed SPI to read bidirectional SDA line
+***************************************************************************************/
+uint8_t TFT_eSPI::tft_Read_8(void)
+{
+  uint8_t  ret = 0;
+
+  for (uint8_t i = 0; i < 8; i++) {  // read results
+    ret <<= 1;
+    SCLK_L;
+    if (digitalRead(TFT_MOSI)) ret |= 1;
+    SCLK_H;
+  }
+
+  return ret;
+}
+
+/***************************************************************************************
+** Function name:           beginSDA
+** Description:             Detach SPI from pin to permit software SPI
+***************************************************************************************/
+void TFT_eSPI::begin_SDA_Read(void)
+{
+  // Release configured SPI port for SDA read
+  spi.end();
+}
+
+/***************************************************************************************
+** Function name:           endSDA
+** Description:             Attach SPI pins after software SPI
+***************************************************************************************/
+void TFT_eSPI::end_SDA_Read(void)
+{
+  // Configure SPI port ready for next TFT access
+  spi.begin();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#endif // #if defined (TFT_SDA_READ)
+////////////////////////////////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+#if defined (TFT_PARALLEL_8_BIT) // Code for generic (i.e. any) processor
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for generic processor and parallel display
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
+
+  while (len>1) {tft_Write_32D(color); len-=2;}
+  if (len) {tft_Write_16(color);}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for gereric processor and parallel display
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
+
+  uint16_t *data = (uint16_t*)data_in;
+  if(_swapBytes) {
+    while (len>1) {tft_Write_16(*data); data++; tft_Write_16(*data); data++; len -=2;}
+    if (len) {tft_Write_16(*data);}
+    return;
+  }
+
+  while (len>1) {tft_Write_16S(*data); data++; tft_Write_16S(*data); data++; len -=2;}
+  if (len) {tft_Write_16S(*data);}
+}
+
+/***************************************************************************************
+** Function name:           GPIO direction control  - supports class functions
+** Description:             Set parallel bus to INPUT or OUTPUT
+***************************************************************************************/
+void TFT_eSPI::busDir(uint32_t mask, uint8_t mode)
+{
+  // mask is unused for generic processor
+  // Arduino native functions suited well to a generic driver
+  pinMode(TFT_D0, mode);
+  pinMode(TFT_D1, mode);
+  pinMode(TFT_D2, mode);
+  pinMode(TFT_D3, mode);
+  pinMode(TFT_D4, mode);
+  pinMode(TFT_D5, mode);
+  pinMode(TFT_D6, mode);
+  pinMode(TFT_D7, mode);
+  return;
+}
+
+/***************************************************************************************
+** Function name:           GPIO direction control  - supports class functions
+** Description:             Faster GPIO pin input/output switch
+***************************************************************************************/
+void TFT_eSPI::gpioMode(uint8_t gpio, uint8_t mode)
+{
+  // No fast port based generic approach available
+}
+
+/***************************************************************************************
+** Function name:           read byte  - supports class functions
+** Description:             Read a byte - parallel bus only
+***************************************************************************************/
+uint8_t TFT_eSPI::readByte(void)
+{
+  uint8_t b = 0;
+
+  busDir(0, INPUT);
+  digitalWrite(TFT_RD, LOW);
+
+  b |= digitalRead(TFT_D0) << 0;
+  b |= digitalRead(TFT_D1) << 1;
+  b |= digitalRead(TFT_D2) << 2;
+  b |= digitalRead(TFT_D3) << 3;
+  b |= digitalRead(TFT_D4) << 4;
+  b |= digitalRead(TFT_D5) << 5;
+  b |= digitalRead(TFT_D6) << 6;
+  b |= digitalRead(TFT_D7) << 7;
+
+  digitalWrite(TFT_RD, HIGH);
+  busDir(0, OUTPUT);
+
+  return b;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#elif defined (RPI_WRITE_STROBE)  // For RPi TFT with write strobe                      
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for ESP32 or STM32 RPi TFT
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
+
+  if(len) { tft_Write_16(color); len--; }
+  while(len--) {WR_L; WR_H;}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for ESP32 or STM32 RPi TFT
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len)
+{
+  uint16_t *data = (uint16_t*)data_in;
+
+  if (_swapBytes) while ( len-- ) {tft_Write_16S(*data); data++;}
+  else while ( len-- ) {tft_Write_16(*data); data++;}
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#elif defined (SPI_18BIT_DRIVER) // SPI 18-bit colour                         
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for STM32 and 3 byte RGB display
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len)
+{
+  // Split out the colours
+  uint8_t r = (color & 0xF800)>>8;
+  uint8_t g = (color & 0x07E0)>>3;
+  uint8_t b = (color & 0x001F)<<3;
+
+  while ( len-- ) {tft_Write_8(r); tft_Write_8(g); tft_Write_8(b);}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for STM32 and 3 byte RGB display
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
+
+  uint16_t *data = (uint16_t*)data_in;
+  if (_swapBytes) {
+    while ( len-- ) {
+      uint16_t color = *data >> 8 | *data << 8;
+      tft_Write_8((color & 0xF800)>>8);
+      tft_Write_8((color & 0x07E0)>>3);
+      tft_Write_8((color & 0x001F)<<3);
+      data++;
+    }
+  }
+  else {
+    while ( len-- ) {
+      tft_Write_8((*data & 0xF800)>>8);
+      tft_Write_8((*data & 0x07E0)>>3);
+      tft_Write_8((*data & 0x001F)<<3);
+      data++;
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#else //                   Standard SPI 16-bit colour TFT                               
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for STM32
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
+
+  while ( len-- ) {tft_Write_16(color);}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for STM32
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
+
+  uint16_t *data = (uint16_t*)data_in;
+
+  if (_swapBytes) while ( len-- ) {tft_Write_16(*data); data++;}
+  else while ( len-- ) {tft_Write_16S(*data); data++;}
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#endif // End of display interface specific functions
+////////////////////////////////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+#ifdef MG24_DMA // DMA functions for 16-bit SPI and 8/16-bit parallel displays
+////////////////////////////////////////////////////////////////////////////////////////
+
+bool DMA_Enabled = false;
+
+/***************************************************************************************
+** Function name:           dmaBusy
+** Description:             Check if DMA is busy (usefully non-blocking!)
+***************************************************************************************/
+// Use while( tft.dmaBusy() ) {Do-something-useful;}"
+bool TFT_eSPI::dmaBusy(void) {
+  return false; // Use spi.transfer's blocking transfer mode, so it always returns false
+}
+
+/***************************************************************************************
+** Function name:           dmaWait
+** Description:             Wait until DMA is over (blocking!)
+***************************************************************************************/
+void TFT_eSPI::dmaWait(void)
+{
+  while (dmaBusy());
+}
+
+/***************************************************************************************
+** Function name:           pushPixelsDMA
+** Description:             Push pixels to TFT
+***************************************************************************************/
+void TFT_eSPI::pushPixelsDMA(uint16_t *image, uint32_t len)
+{
+  if (!DMA_Enabled || len == 0) return;
+  
+  if(_swapBytes) {
+    for (uint32_t i = 0; i < len; i++) (image[i] = image[i] << 8 | image[i] >> 8);
+  }
+
+  dmaWait();
+  spi.transfer(image, len * 2, true);
+}
+
+/***************************************************************************************
+** Function name:           pushImageDMA
+** Description:             Push image to a window (w*h must be less than 65536)
+***************************************************************************************/
+// This will clip and also swap bytes if setSwapBytes(true) was called by sketch
+void TFT_eSPI::pushImageDMA(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t* image, uint16_t* buffer) 
+{
+  if ((x >= _vpW) || (y >= _vpH)) return;
+
+  int32_t dx = 0;
+  int32_t dy = 0;
+  int32_t dw = w;
+  int32_t dh = h;
+
+  if (x < _vpX) { dx = _vpX - x; dw -= dx; x = _vpX; }
+  if (y < _vpY) { dy = _vpY - y; dh -= dy; y = _vpY; }
+
+  if ((x + dw) > _vpW ) dw = _vpW - x;
+  if ((y + dh) > _vpH ) dh = _vpH - y;
+
+  if (dw < 1 || dh < 1) return;
+
+  uint32_t len = dw*dh;
+
+  if (buffer == nullptr) {
+    buffer = image;
+    dmaWait();
+  }
+
+  // If image is clipped, copy pixels into a contiguous block
+  if ( (dw != w) || (dh != h) ) {
+    if(_swapBytes) {
+      for (int32_t yb = 0; yb < dh; yb++) {
+        for (int32_t xb = 0; xb < dw; xb++) {
+          uint32_t src = xb + dx + w * (yb + dy);
+          (buffer[xb + yb * dw] = image[src] << 8 | image[src] >> 8);
+        }
+      }
+    }
+    else {
+      for (int32_t yb = 0; yb < dh; yb++) {
+        memcpy((uint8_t*) (buffer + yb * dw), (uint8_t*) (image + dx + w * (yb + dy)), dw << 1);
+      }
+    }
+  }
+  // else, if a buffer pointer has been provided copy whole image to the buffer
+  else if (buffer != image || _swapBytes) {
+    if(_swapBytes) {
+      for (uint32_t i = 0; i < len; i++) (buffer[i] = image[i] << 8 | image[i] >> 8);
+    }
+    else {
+      memcpy(buffer, image, len*2);
+    }
+  }
+
+  setWindow(x, y, x + dw - 1, y + dh - 1);
+
+  const uint32_t DMA_MAX_TX_SIZE = 0x7fff;
+  while(len>DMA_MAX_TX_SIZE) { // Transfer 16-bit pixels in blocks if len*2 over 65534 bytes
+    dmaWait();
+    spi.transfer((uint16_t*)buffer, DMA_MAX_TX_SIZE * 2, true);
+    len -= DMA_MAX_TX_SIZE; buffer+= DMA_MAX_TX_SIZE; // Arbitrarily send 1K pixel blocks (2Kbytes)
+  }
+  dmaWait();
+  // Send remaining pixels using DMA (max 65534 bytes)
+  spi.transfer((uint16_t*)buffer, len * 2, true);
+   
+}
+
+/***************************************************************************************
+** Function name:           initDMA
+** Description:             Initialise the DMA engine - returns true if init OK
+***************************************************************************************/
+bool TFT_eSPI::initDMA(bool ctrl_cs) {
+  if (DMA_Enabled) return false;
+
+  DMA_Enabled = true;
+  return true;
+}
+  
+/***************************************************************************************
+** Function name:           deInitDMA
+** Description:             Disconnect the DMA engine from SPI
+***************************************************************************************/
+void TFT_eSPI::deInitDMA(void)
+{
+  if (!DMA_Enabled) return;
+  DMA_Enabled = false;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#endif // End of DMA FUNCTIONS
+////////////////////////////////////////////////////////////////////////////////////////

--- a/Processors/TFT_eSPI_MG24.h
+++ b/Processors/TFT_eSPI_MG24.h
@@ -1,0 +1,172 @@
+        ////////////////////////////////////////////////////
+        //       TFT_eSPI XIAO_MG24 driver functions    //
+        ////////////////////////////////////////////////////
+
+
+#ifndef _TFT_eSPI_MG24H_
+#define _TFT_eSPI_MG24H_
+
+// Processor ID reported by getSetup()
+#define PROCESSOR_ID 0x21
+
+// Include processor specific header
+#include "SPI.h"
+
+#define SET_BUS_WRITE_MODE
+#define SET_BUS_READ_MODE
+
+#define MG24_DMA
+
+// #define SPI_BUSY_CHECK spi.waitForTransfer();
+
+
+// Code to check if DMA is busy, used by SPI bus transaction startWrite and endWrite functions
+#define DMA_BUSY_CHECK dmaWait()
+
+// To be safe, SUPPORT_TRANSACTIONS is assumed mandatory
+#if !defined (SUPPORT_TRANSACTIONS)
+  #define SUPPORT_TRANSACTIONS
+#endif
+
+#define INIT_TFT_DATA_BUS
+
+#ifdef SMOOTH_FONT
+  // #define FS_NO_GLOBALS
+  // #include <Seeed_Arduino_FS.h>
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the DC (TFT Data/Command or Register Select (RS))pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_DC
+  #define DC_C // No macro allocated so it generates no code
+  #define DC_D // No macro allocated so it generates no code
+#else
+  #define DC_C digitalWrite(TFT_DC, LOW)
+  #define DC_D digitalWrite(TFT_DC, HIGH)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the CS (TFT chip select) pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_CS
+  #define CS_L // No macro allocated so it generates no code
+  #define CS_H // No macro allocated so it generates no code
+#else
+  #define CS_L digitalWrite(TFT_CS, LOW)
+  #define CS_H digitalWrite(TFT_CS, HIGH)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Make sure TFT_RD is defined if not used to avoid an error message
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_RD
+  #define TFT_RD -1
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the WR (TFT Write) pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#ifdef TFT_WR
+  #define WR_L digitalWrite(TFT_WR, LOW)
+  #define WR_H digitalWrite(TFT_WR, HIGH)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the touch screen chip select pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#if !defined TOUCH_CS || (TOUCH_CS < 0)
+  #define T_CS_L // No macro allocated so it generates no code
+  #define T_CS_H // No macro allocated so it generates no code
+#else
+  #define T_CS_L digitalWrite(TOUCH_CS, LOW)
+  #define T_CS_H digitalWrite(TOUCH_CS, HIGH)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Make sure TFT_MISO is defined if not used to avoid an error message
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_MISO
+  #define TFT_MISO -1
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Macros to write commands/pixel colour data to a SPI ILI948x TFT
+////////////////////////////////////////////////////////////////////////////////////////
+#if defined (SPI_18BIT_DRIVER)
+
+  // Write 8 bits to TFT
+  #define tft_Write_8(C)   spi.transfer(C)
+  
+  // Convert 16-bit colour to 18-bit and write in 3 bytes
+  #define tft_Write_16(C)  spi.transfer(((C) & 0xF800)>>8); \
+                           spi.transfer(((C) & 0x07E0)>>3); \
+                           spi.transfer(((C) & 0x001F)<<3)
+
+  // Convert swapped byte 16-bit colour to 18-bit and write in 3 bytes
+  #define tft_Write_16S(C) spi.transfer((C) & 0xF8); \
+                           spi.transfer(((C) & 0xE000)>>11 | ((C) & 0x07)<<5); \
+                           spi.transfer(((C) & 0x1F00)>>5)
+  // Write 32 bits to TFT
+  #define tft_Write_32(C)  spi.transfer16((C)>>16); spi.transfer16((uint16_t)(C))
+
+  // Write two address coordinates
+  #define tft_Write_32C(C,D) spi.transfer16(C); spi.transfer16(D)
+
+// Write same value twice
+  #define tft_Write_32D(C) spi.transfer16(C); spi.transfer16(C)
+////////////////////////////////////////////////////////////////////////////////////////
+// Macros to write commands/pixel colour data to other displays
+////////////////////////////////////////////////////////////////////////////////////////
+#else
+  #if defined (RPI_DISPLAY_TYPE)
+    #define tft_Write_8(C)   spi.transfer(C); spi.transfer(C)
+    #define tft_Write_16(C)  spi.transfer((uint8_t)((C)>>8));spi.transfer((uint8_t)((C)>>0))
+    #define tft_Write_16S(C) spi.transfer((uint8_t)((C)>>0));spi.transfer((uint8_t)((C)>>8))
+    #define tft_Write_32(C) \
+      tft_Write_16((uint16_t) ((C)>>16)); \
+      tft_Write_16((uint16_t) ((C)>>0))
+    #define tft_Write_32C(C,D) \
+      spi.transfer(0); spi.transfer((C)>>8); \
+      spi.transfer(0); spi.transfer((C)>>0); \
+      spi.transfer(0); spi.transfer((D)>>8); \
+      spi.transfer(0); spi.transfer((D)>>0)
+    #define tft_Write_32D(C) \
+      spi.transfer(0); spi.transfer((C)>>8); \
+      spi.transfer(0); spi.transfer((C)>>0); \
+      spi.transfer(0); spi.transfer((C)>>8); \
+      spi.transfer(0); spi.transfer((C)>>0)
+  #else
+    #define tft_Write_8(C)   spi.transfer(C)
+    #define tft_Write_16(C)  spi.transfer16(C)
+    #define tft_Write_16S(C) spi.transfer16(((C)>>8) | ((C)<<8))
+    #define tft_Write_32(C) \
+      tft_Write_16((uint16_t) ((C)>>16)); \
+      tft_Write_16((uint16_t) ((C)>>0))
+    #define tft_Write_32C(C,D) \
+      tft_Write_16((uint16_t) (C)); \
+      tft_Write_16((uint16_t) (D))
+    #define tft_Write_32D(C) \
+      tft_Write_16((uint16_t) (C)); \
+      tft_Write_16((uint16_t) (C))
+  #endif
+#endif
+
+#ifndef tft_Write_16N
+  #define tft_Write_16N tft_Write_16
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Macros to read from display using SPI or software SPI
+////////////////////////////////////////////////////////////////////////////////////////
+#if defined (TFT_SDA_READ)
+  // Use a bit banged function call for STM32 and bi-directional SDA pin
+  #define TFT_eSPI_ENABLE_8_BIT_READ // Enable tft_Read_8(void);
+  #define SCLK_L digitalWrite(TFT_SCLK, LOW)
+  #define SCLK_H digitalWrite(TFT_SCLK, HIGH)
+#else
+  // Use a SPI read transfer
+  #define tft_Read_8() spi.transfer(0)
+#endif
+
+#endif // Header end

--- a/Processors/TFT_eSPI_RA4M1.c
+++ b/Processors/TFT_eSPI_RA4M1.c
@@ -1,0 +1,378 @@
+////////////////////////////////////////////////////
+//       TFT_eSPI XIAO_RA4M1 driver functions     //
+////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Global variables
+////////////////////////////////////////////////////////////////////////////////////////
+// Select the SPI port to use
+#ifdef TFT_SPI_PORT
+  SPIClass& spi = TFT_SPI_PORT;
+#else
+  SPIClass& spi = SPI;
+#endif
+
+#if defined (TFT_SDA_READ) && !defined (TFT_PARALLEL_8_BIT)
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           tft_Read_8
+** Description:             Bit bashed SPI to read bidirectional SDA line
+***************************************************************************************/
+uint8_t TFT_eSPI::tft_Read_8(void)
+{
+  uint8_t  ret = 0;
+
+  for (uint8_t i = 0; i < 8; i++) {  // read results
+    ret <<= 1;
+    SCLK_L;
+    if (digitalRead(TFT_MOSI)) ret |= 1;
+    SCLK_H;
+  }
+
+  return ret;
+}
+
+/***************************************************************************************
+** Function name:           beginSDA
+** Description:             Detach SPI from pin to permit software SPI
+***************************************************************************************/
+void TFT_eSPI::begin_SDA_Read(void)
+{
+  // Release configured SPI port for SDA read
+  spi.end();
+}
+
+/***************************************************************************************
+** Function name:           endSDA
+** Description:             Attach SPI pins after software SPI
+***************************************************************************************/
+void TFT_eSPI::end_SDA_Read(void)
+{
+  // Configure SPI port ready for next TFT access
+  spi.begin();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#endif // #if defined (TFT_SDA_READ)
+////////////////////////////////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+#if defined (TFT_PARALLEL_8_BIT) // Code for generic (i.e. any) processor
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for generic processor and parallel display
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
+
+  while (len>1) {tft_Write_32D(color); len-=2;}
+  if (len) {tft_Write_16(color);}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for gereric processor and parallel display
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
+
+  uint16_t *data = (uint16_t*)data_in;
+  if(_swapBytes) {
+    while (len>1) {tft_Write_16(*data); data++; tft_Write_16(*data); data++; len -=2;}
+    if (len) {tft_Write_16(*data);}
+    return;
+  }
+
+  while (len>1) {tft_Write_16S(*data); data++; tft_Write_16S(*data); data++; len -=2;}
+  if (len) {tft_Write_16S(*data);}
+}
+
+/***************************************************************************************
+** Function name:           GPIO direction control  - supports class functions
+** Description:             Set parallel bus to INPUT or OUTPUT
+***************************************************************************************/
+void TFT_eSPI::busDir(uint32_t mask, uint8_t mode)
+{
+  // mask is unused for generic processor
+  // Arduino native functions suited well to a generic driver
+  pinMode(TFT_D0, mode);
+  pinMode(TFT_D1, mode);
+  pinMode(TFT_D2, mode);
+  pinMode(TFT_D3, mode);
+  pinMode(TFT_D4, mode);
+  pinMode(TFT_D5, mode);
+  pinMode(TFT_D6, mode);
+  pinMode(TFT_D7, mode);
+  return;
+}
+
+/***************************************************************************************
+** Function name:           GPIO direction control  - supports class functions
+** Description:             Faster GPIO pin input/output switch
+***************************************************************************************/
+void TFT_eSPI::gpioMode(uint8_t gpio, uint8_t mode)
+{
+  // No fast port based generic approach available
+}
+
+/***************************************************************************************
+** Function name:           read byte  - supports class functions
+** Description:             Read a byte - parallel bus only
+***************************************************************************************/
+uint8_t TFT_eSPI::readByte(void)
+{
+  uint8_t b = 0;
+
+  busDir(0, INPUT);
+  digitalWrite(TFT_RD, LOW);
+
+  b |= digitalRead(TFT_D0) << 0;
+  b |= digitalRead(TFT_D1) << 1;
+  b |= digitalRead(TFT_D2) << 2;
+  b |= digitalRead(TFT_D3) << 3;
+  b |= digitalRead(TFT_D4) << 4;
+  b |= digitalRead(TFT_D5) << 5;
+  b |= digitalRead(TFT_D6) << 6;
+  b |= digitalRead(TFT_D7) << 7;
+
+  digitalWrite(TFT_RD, HIGH);
+  busDir(0, OUTPUT);
+
+  return b;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#elif defined (RPI_WRITE_STROBE)  // For RPi TFT with write strobe                      
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for ESP32 or STM32 RPi TFT
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
+
+  if(len) { tft_Write_16(color); len--; }
+  while(len--) {WR_L; WR_H;}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for ESP32 or STM32 RPi TFT
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len)
+{
+  uint16_t *data = (uint16_t*)data_in;
+
+  if (_swapBytes) while ( len-- ) {tft_Write_16S(*data); data++;}
+  else while ( len-- ) {tft_Write_16(*data); data++;}
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#elif defined (SPI_18BIT_DRIVER) // SPI 18-bit colour                         
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for STM32 and 3 byte RGB display
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len)
+{
+  // Split out the colours
+  uint8_t r = (color & 0xF800)>>8;
+  uint8_t g = (color & 0x07E0)>>3;
+  uint8_t b = (color & 0x001F)<<3;
+
+  while ( len-- ) {tft_Write_8(r); tft_Write_8(g); tft_Write_8(b);}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for STM32 and 3 byte RGB display
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
+
+  uint16_t *data = (uint16_t*)data_in;
+  if (_swapBytes) {
+    while ( len-- ) {
+      uint16_t color = *data >> 8 | *data << 8;
+      tft_Write_8((color & 0xF800)>>8);
+      tft_Write_8((color & 0x07E0)>>3);
+      tft_Write_8((color & 0x001F)<<3);
+      data++;
+    }
+  }
+  else {
+    while ( len-- ) {
+      tft_Write_8((*data & 0xF800)>>8);
+      tft_Write_8((*data & 0x07E0)>>3);
+      tft_Write_8((*data & 0x001F)<<3);
+      data++;
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#else //                   Standard SPI 16-bit colour TFT                               
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for STM32
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
+
+  while ( len-- ) {tft_Write_16(color);}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for STM32
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
+
+  uint16_t *data = (uint16_t*)data_in;
+
+  if (_swapBytes) while ( len-- ) {tft_Write_16(*data); data++;}
+  else while ( len-- ) {tft_Write_16S(*data); data++;}
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#endif // End of display interface specific functions
+////////////////////////////////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+#ifdef RA4M1_DMA // DMA functions for 16-bit SPI and 8/16-bit parallel displays
+////////////////////////////////////////////////////////////////////////////////////////
+
+bool DMA_Enabled = false;
+
+/***************************************************************************************
+** Function name:           dmaBusy
+** Description:             Check if DMA is busy (usefully non-blocking!)
+***************************************************************************************/
+// Use while( tft.dmaBusy() ) {Do-something-useful;}"
+bool TFT_eSPI::dmaBusy(void) {
+  return R_SPI1->SPSR_b.IDLNF; 
+}
+
+/***************************************************************************************
+** Function name:           dmaWait
+** Description:             Wait until DMA is over (blocking!)
+***************************************************************************************/
+void TFT_eSPI::dmaWait(void)
+{
+  while (dmaBusy());
+}
+
+/***************************************************************************************
+** Function name:           pushPixelsDMA
+** Description:             Push pixels to TFT
+***************************************************************************************/
+void TFT_eSPI::pushPixelsDMA(uint16_t *image, uint32_t len)
+{
+  if (!DMA_Enabled || len == 0) return;
+  
+  if(_swapBytes) {
+    for (uint32_t i = 0; i < len; i++) (image[i] = image[i] << 8 | image[i] >> 8);
+  }
+
+  dmaWait();
+  spi.transfer(image, len * 2); // 16-bit pixels
+}
+
+/***************************************************************************************
+** Function name:           pushImageDMA
+** Description:             Push image to a window (w*h must be less than 65536)
+***************************************************************************************/
+// This will clip and also swap bytes if setSwapBytes(true) was called by sketch
+void TFT_eSPI::pushImageDMA(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t* image, uint16_t* buffer) 
+{
+  if ((x >= _vpW) || (y >= _vpH)) return;
+
+  int32_t dx = 0;
+  int32_t dy = 0;
+  int32_t dw = w;
+  int32_t dh = h;
+
+  if (x < _vpX) { dx = _vpX - x; dw -= dx; x = _vpX; }
+  if (y < _vpY) { dy = _vpY - y; dh -= dy; y = _vpY; }
+
+  if ((x + dw) > _vpW ) dw = _vpW - x;
+  if ((y + dh) > _vpH ) dh = _vpH - y;
+
+  if (dw < 1 || dh < 1) return;
+
+  uint32_t len = dw*dh;
+
+  if (buffer == nullptr) {
+    buffer = image;
+    dmaWait();
+  }
+
+  // If image is clipped, copy pixels into a contiguous block
+  if ( (dw != w) || (dh != h) ) {
+    if(_swapBytes) {
+      for (int32_t yb = 0; yb < dh; yb++) {
+        for (int32_t xb = 0; xb < dw; xb++) {
+          uint32_t src = xb + dx + w * (yb + dy);
+          (buffer[xb + yb * dw] = image[src] << 8 | image[src] >> 8);
+        }
+      }
+    }
+    else {
+      for (int32_t yb = 0; yb < dh; yb++) {
+        memcpy((uint8_t*) (buffer + yb * dw), (uint8_t*) (image + dx + w * (yb + dy)), dw << 1);
+      }
+    }
+  }
+  // else, if a buffer pointer has been provided copy whole image to the buffer
+  else if (buffer != image || _swapBytes) {
+    if(_swapBytes) {
+      for (uint32_t i = 0; i < len; i++) (buffer[i] = image[i] << 8 | image[i] >> 8);
+    }
+    else {
+      memcpy(buffer, image, len*2);
+    }
+  }
+
+  setWindow(x, y, x + dw - 1, y + dh - 1);
+
+  const uint32_t DMA_MAX_TX_SIZE = 0x7fff;
+  while(len>DMA_MAX_TX_SIZE) { // Transfer 16-bit pixels in blocks if len*2 over 65534 bytes
+    dmaWait();
+    spi.transfer((uint16_t*)buffer, DMA_MAX_TX_SIZE * 2);
+    len -= DMA_MAX_TX_SIZE; buffer+= DMA_MAX_TX_SIZE; // Arbitrarily send 1K pixel blocks (2Kbytes)
+  }
+  dmaWait();
+  // Send remaining pixels using DMA (max 65534 bytes)
+  spi.transfer((uint16_t*)buffer, len * 2);
+   
+}
+
+/***************************************************************************************
+** Function name:           initDMA
+** Description:             Initialise the DMA engine - returns true if init OK
+***************************************************************************************/
+bool TFT_eSPI::initDMA(bool ctrl_cs) {
+  if (DMA_Enabled) return false;
+
+  DMA_Enabled = true;
+  return true;
+}
+  
+/***************************************************************************************
+** Function name:           deInitDMA
+** Description:             Disconnect the DMA engine from SPI
+***************************************************************************************/
+void TFT_eSPI::deInitDMA(void)
+{
+  if (!DMA_Enabled) return;
+  DMA_Enabled = false;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#endif // End of DMA FUNCTIONS
+////////////////////////////////////////////////////////////////////////////////////////

--- a/Processors/TFT_eSPI_RA4M1.h
+++ b/Processors/TFT_eSPI_RA4M1.h
@@ -1,0 +1,188 @@
+        ////////////////////////////////////////////////////
+        //       TFT_eSPI XIAO_RA4M1 driver functions     //
+        ////////////////////////////////////////////////////
+
+
+#ifndef _TFT_eSPI_RA4M1H_
+#define _TFT_eSPI_RA4M1H_
+
+// Processor ID reported by getSetup()
+#define PROCESSOR_ID 0x21
+
+// Include processor specific header
+#include "SPI.h"
+#include "r_spi.h" // FSP header for DTC (DMA) driver
+
+#define SET_BUS_WRITE_MODE
+#define SET_BUS_READ_MODE
+
+#define RA4M1_DMA
+
+
+
+// #define SPI_BUSY_CHECK spi.waitForTransfer();
+
+// Code to check if DMA is busy, used by SPI bus transaction startWrite and endWrite functions
+#define DMA_BUSY_CHECK dmaWait()
+
+// To be safe, SUPPORT_TRANSACTIONS is assumed mandatory
+#if !defined (SUPPORT_TRANSACTIONS)
+  #define SUPPORT_TRANSACTIONS
+#endif
+
+#define INIT_TFT_DATA_BUS
+
+#ifdef SMOOTH_FONT
+  // #define FS_NO_GLOBALS
+  #include <Seeed_Arduino_FS.h>
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the DC (TFT Data/Command or Register Select (RS))pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_DC
+  #define DC_C // No macro allocated so it generates no code
+  #define DC_D // No macro allocated so it generates no code
+#else
+  #define DC_C digitalWrite(TFT_DC, LOW)
+  #define DC_D digitalWrite(TFT_DC, HIGH)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the CS (TFT chip select) pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_CS
+  #define CS_L // No macro allocated so it generates no code
+  #define CS_H // No macro allocated so it generates no code
+#else
+  #define CS_L digitalWrite(TFT_CS, LOW)
+  #define CS_H digitalWrite(TFT_CS, HIGH)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Make sure TFT_RD is defined if not used to avoid an error message
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_RD
+  #define TFT_RD -1
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the WR (TFT Write) pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#ifdef TFT_WR
+  #define WR_L digitalWrite(TFT_WR, LOW)
+  #define WR_H digitalWrite(TFT_WR, HIGH)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the touch screen chip select pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#if !defined TOUCH_CS || (TOUCH_CS < 0)
+  #define T_CS_L // No macro allocated so it generates no code
+  #define T_CS_H // No macro allocated so it generates no code
+#else
+  #define T_CS_L digitalWrite(TOUCH_CS, LOW)
+  #define T_CS_H digitalWrite(TOUCH_CS, HIGH)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Make sure TFT_MISO is defined if not used to avoid an error message
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_MISO
+  #define TFT_MISO -1
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Macros to write commands/pixel colour data to a SPI ILI948x TFT
+////////////////////////////////////////////////////////////////////////////////////////
+#if  defined (SPI_18BIT_DRIVER) // SPI 18-bit colour
+
+  // Write 8 bits to TFT
+  #define tft_Write_8(C)   spi.transfer(C)
+
+  // Convert 16-bit colour to 18-bit and write in 3 bytes
+  #define tft_Write_16(C)  spi.transfer(((C) & 0xF800)>>8); \
+                           spi.transfer(((C) & 0x07E0)>>3); \
+                           spi.transfer(((C) & 0x001F)<<3)
+
+  // Convert swapped byte 16-bit colour to 18-bit and write in 3 bytes
+  #define tft_Write_16S(C) spi.transfer((C) & 0xF8); \
+                           spi.transfer(((C) & 0xE000)>>11 | ((C) & 0x07)<<5); \
+                           spi.transfer(((C) & 0x1F00)>>5)
+  // Write 32 bits to TFT
+  #define tft_Write_32(C)  spi.transfer16((C)>>16); spi.transfer16((uint16_t)(C))
+
+  // Write two address coordinates
+  #define tft_Write_32C(C,D) spi.transfer16(C); spi.transfer16(D)
+
+  // Write same value twice
+  #define tft_Write_32D(C) spi.transfer16(C); spi.transfer16(C)
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Macros to write commands/pixel colour data to other displays
+////////////////////////////////////////////////////////////////////////////////////////
+#else
+  #if  defined (RPI_DISPLAY_TYPE) // RPi TFT type always needs 16-bit transfers
+    #define tft_Write_8(C)   spi.transfer(C); spi.transfer(C)
+    #define tft_Write_16(C)  spi.transfer((uint8_t)((C)>>8));spi.transfer((uint8_t)((C)>>0))
+    #define tft_Write_16S(C) spi.transfer((uint8_t)((C)>>0));spi.transfer((uint8_t)((C)>>8))
+
+    #define tft_Write_32(C) \
+      tft_Write_16((uint16_t) ((C)>>16)); \
+      tft_Write_16((uint16_t) ((C)>>0))
+
+    #define tft_Write_32C(C,D) \
+      spi.transfer(0); spi.transfer((C)>>8); \
+      spi.transfer(0); spi.transfer((C)>>0); \
+      spi.transfer(0); spi.transfer((D)>>8); \
+      spi.transfer(0); spi.transfer((D)>>0)
+
+    #define tft_Write_32D(C) \
+      spi.transfer(0); spi.transfer((C)>>8); \
+      spi.transfer(0); spi.transfer((C)>>0); \
+      spi.transfer(0); spi.transfer((C)>>8); \
+      spi.transfer(0); spi.transfer((C)>>0)
+
+  #else
+    #ifdef __AVR__ // AVR processors do not have 16-bit transfer
+      #define tft_Write_8(C)   {SPDR=(C); while (!(SPSR&_BV(SPIF)));}
+      #define tft_Write_16(C)  tft_Write_8((uint8_t)((C)>>8));tft_Write_8((uint8_t)((C)>>0))
+      #define tft_Write_16S(C) tft_Write_8((uint8_t)((C)>>0));tft_Write_8((uint8_t)((C)>>8))
+    #else
+      #define tft_Write_8(C)   spi.transfer(C)
+      #define tft_Write_16(C)  spi.transfer16(C)
+      #define tft_Write_16S(C) spi.transfer16(((C)>>8) | ((C)<<8))
+    #endif // AVR    
+
+    #define tft_Write_32(C) \
+    tft_Write_16((uint16_t) ((C)>>16)); \
+    tft_Write_16((uint16_t) ((C)>>0))
+
+    #define tft_Write_32C(C,D) \
+    tft_Write_16((uint16_t) (C)); \
+    tft_Write_16((uint16_t) (D))
+
+    #define tft_Write_32D(C) \
+    tft_Write_16((uint16_t) (C)); \
+    tft_Write_16((uint16_t) (C))
+  #endif // RPI_DISPLAY_TYPE
+#endif
+
+#ifndef tft_Write_16N
+  #define tft_Write_16N tft_Write_16
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Macros to read from display using SPI or software SPI
+////////////////////////////////////////////////////////////////////////////////////////
+#if defined (TFT_SDA_READ)
+  // Use a bit banged function call for STM32 and bi-directional SDA pin
+  #define TFT_eSPI_ENABLE_8_BIT_READ // Enable tft_Read_8(void);
+  #define SCLK_L digitalWrite(TFT_SCLK, LOW)
+  #define SCLK_H digitalWrite(TFT_SCLK, HIGH)
+#else
+  // Use a SPI read transfer
+  #define tft_Read_8() spi.transfer(0)
+#endif
+
+#endif // Header end

--- a/Processors/TFT_eSPI_SAMD21.c
+++ b/Processors/TFT_eSPI_SAMD21.c
@@ -1,0 +1,418 @@
+////////////////////////////////////////////////////
+//       TFT_eSPI XIAO_SAMD21 driver functions    //
+////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Global variables
+////////////////////////////////////////////////////////////////////////////////////////
+// Select the SPI port to use
+#ifdef TFT_SPI_PORT
+  SPIClass& spi = TFT_SPI_PORT;
+#else
+  SPIClass& spi = SPI;
+#endif
+
+#if defined (TFT_SDA_READ) && !defined (TFT_PARALLEL_8_BIT)
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           tft_Read_8
+** Description:             Bit bashed SPI to read bidirectional SDA line
+***************************************************************************************/
+uint8_t TFT_eSPI::tft_Read_8(void)
+{
+  uint8_t  ret = 0;
+
+  for (uint8_t i = 0; i < 8; i++) {  // read results
+    ret <<= 1;
+    SCLK_L;
+    if (digitalRead(TFT_MOSI)) ret |= 1;
+    SCLK_H;
+  }
+
+  return ret;
+}
+
+/***************************************************************************************
+** Function name:           beginSDA
+** Description:             Detach SPI from pin to permit software SPI
+***************************************************************************************/
+void TFT_eSPI::begin_SDA_Read(void)
+{
+  // Release configured SPI port for SDA read
+  spi.end();
+}
+
+/***************************************************************************************
+** Function name:           endSDA
+** Description:             Attach SPI pins after software SPI
+***************************************************************************************/
+void TFT_eSPI::end_SDA_Read(void)
+{
+  // Configure SPI port ready for next TFT access
+  spi.begin();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#endif // #if defined (TFT_SDA_READ)
+////////////////////////////////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+#if defined (TFT_PARALLEL_8_BIT) // Code for generic (i.e. any) processor
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for generic processor and parallel display
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
+
+  while (len>1) {tft_Write_32D(color); len-=2;}
+  if (len) {tft_Write_16(color);}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for gereric processor and parallel display
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
+
+  uint16_t *data = (uint16_t*)data_in;
+  if(_swapBytes) {
+    while (len>1) {tft_Write_16(*data); data++; tft_Write_16(*data); data++; len -=2;}
+    if (len) {tft_Write_16(*data);}
+    return;
+  }
+
+  while (len>1) {tft_Write_16S(*data); data++; tft_Write_16S(*data); data++; len -=2;}
+  if (len) {tft_Write_16S(*data);}
+}
+
+/***************************************************************************************
+** Function name:           GPIO direction control  - supports class functions
+** Description:             Set parallel bus to INPUT or OUTPUT
+***************************************************************************************/
+void TFT_eSPI::busDir(uint32_t mask, uint8_t mode)
+{
+  // mask is unused for generic processor
+  // Arduino native functions suited well to a generic driver
+  pinMode(TFT_D0, mode);
+  pinMode(TFT_D1, mode);
+  pinMode(TFT_D2, mode);
+  pinMode(TFT_D3, mode);
+  pinMode(TFT_D4, mode);
+  pinMode(TFT_D5, mode);
+  pinMode(TFT_D6, mode);
+  pinMode(TFT_D7, mode);
+  return;
+}
+
+/***************************************************************************************
+** Function name:           GPIO direction control  - supports class functions
+** Description:             Faster GPIO pin input/output switch
+***************************************************************************************/
+void TFT_eSPI::gpioMode(uint8_t gpio, uint8_t mode)
+{
+  // No fast port based generic approach available
+}
+
+/***************************************************************************************
+** Function name:           read byte  - supports class functions
+** Description:             Read a byte - parallel bus only
+***************************************************************************************/
+uint8_t TFT_eSPI::readByte(void)
+{
+  uint8_t b = 0;
+
+  busDir(0, INPUT);
+  digitalWrite(TFT_RD, LOW);
+
+  b |= digitalRead(TFT_D0) << 0;
+  b |= digitalRead(TFT_D1) << 1;
+  b |= digitalRead(TFT_D2) << 2;
+  b |= digitalRead(TFT_D3) << 3;
+  b |= digitalRead(TFT_D4) << 4;
+  b |= digitalRead(TFT_D5) << 5;
+  b |= digitalRead(TFT_D6) << 6;
+  b |= digitalRead(TFT_D7) << 7;
+
+  digitalWrite(TFT_RD, HIGH);
+  busDir(0, OUTPUT);
+
+  return b;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#elif defined (RPI_WRITE_STROBE)  // For RPi TFT with write strobe                      
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for ESP32 or STM32 RPi TFT
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
+
+  if(len) { tft_Write_16(color); len--; }
+  while(len--) {WR_L; WR_H;}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for ESP32 or STM32 RPi TFT
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len)
+{
+  uint16_t *data = (uint16_t*)data_in;
+
+  if (_swapBytes) while ( len-- ) {tft_Write_16S(*data); data++;}
+  else while ( len-- ) {tft_Write_16(*data); data++;}
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#elif defined (SPI_18BIT_DRIVER) // SPI 18-bit colour                         
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for STM32 and 3 byte RGB display
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len)
+{
+  // Split out the colours
+  uint8_t r = (color & 0xF800)>>8;
+  uint8_t g = (color & 0x07E0)>>3;
+  uint8_t b = (color & 0x001F)<<3;
+
+  while ( len-- ) {tft_Write_8(r); tft_Write_8(g); tft_Write_8(b);}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for STM32 and 3 byte RGB display
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
+
+  uint16_t *data = (uint16_t*)data_in;
+  if (_swapBytes) {
+    while ( len-- ) {
+      uint16_t color = *data >> 8 | *data << 8;
+      tft_Write_8((color & 0xF800)>>8);
+      tft_Write_8((color & 0x07E0)>>3);
+      tft_Write_8((color & 0x001F)<<3);
+      data++;
+    }
+  }
+  else {
+    while ( len-- ) {
+      tft_Write_8((*data & 0xF800)>>8);
+      tft_Write_8((*data & 0x07E0)>>3);
+      tft_Write_8((*data & 0x001F)<<3);
+      data++;
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#else //                   Standard SPI 16-bit colour TFT                               
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for STM32
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
+
+  while ( len-- ) {tft_Write_16(color);}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for STM32
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
+
+  uint16_t *data = (uint16_t*)data_in;
+
+  if (_swapBytes) while ( len-- ) {tft_Write_16(*data); data++;}
+  else while ( len-- ) {tft_Write_16S(*data); data++;}
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#endif // End of display interface specific functions
+////////////////////////////////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+//                                DMA FUNCTIONS
+////////////////////////////////////////////////////////////////////////////////////////
+
+Adafruit_ZeroDMA zDMA;
+ZeroDMAstatus stat;
+DmacDescriptor *desc;
+bool DMA_Enabled = false;
+volatile bool spiBusyCheck = false;
+
+
+void dmaCallback(Adafruit_ZeroDMA *dma)
+{
+
+  spiBusyCheck = false;
+}
+/***************************************************************************************
+** Function name:           initDMA
+** Description:             Initialise the DMA engine - returns true if init OK
+***************************************************************************************/
+bool TFT_eSPI::initDMA(bool ctrl_cs) {
+  if (DMA_Enabled) return false;
+  zDMA.setTrigger(SERCOM0_DMAC_ID_TX);
+  zDMA.setAction(DMA_TRIGGER_ACTON_BEAT);
+
+  stat = zDMA.allocate();
+  zDMA.setCallback(dmaCallback);
+
+  DMAC->CHID.bit.ID = zDMA.getChannel();
+  DMAC->CHINTENSET.reg = DMAC_CHINTENSET_TCMPL;
+  zDMA.setPriority(DMA_PRIORITY_3);
+  desc = zDMA.addDescriptor(
+    NULL,                           // Source address (set later)
+    (void *)&SERCOM0->SPI.DATA.reg, // Dest (SPI data register)
+    0,                              // Count (set later)
+    DMA_BEAT_SIZE_BYTE,             // Bytes/hwords/words
+    true,                           // Increment source address
+    false);                         // Don't increment dest address
+
+  NVIC_EnableIRQ(DMAC_IRQn); 
+
+  if (ctrl_cs && TFT_CS >= 0)
+  {
+    pinMode(TFT_CS, OUTPUT);
+    digitalWrite(TFT_CS, HIGH);
+  }
+
+  DMA_Enabled = true;
+  spiBusyCheck = false;
+  return true;
+}
+
+/***************************************************************************************
+** Function name:           deInitDMA
+** Description:             Disconnect the DMA engine from SPI
+***************************************************************************************/
+void TFT_eSPI::deInitDMA(void)
+{
+  if (!DMA_Enabled) return;
+  zDMA.free();
+  DMA_Enabled = false;
+  spiBusyCheck = false; // 确保清理状态
+}
+
+/***************************************************************************************
+** Function name:           dmaBusy
+** Description:             Check if DMA is busy (usefully non-blocking!)
+***************************************************************************************/
+// Use while( tft.dmaBusy() ) {Do-something-useful;}"
+bool TFT_eSPI::dmaBusy(void) {
+  bool isActive = zDMA.isActive();
+  if (!isActive) {
+    spiBusyCheck = false;
+  }
+  return  spiBusyCheck;
+}
+
+/***************************************************************************************
+** Function name:           dmaWait
+** Description:             Wait until DMA is over (blocking!)
+***************************************************************************************/
+void TFT_eSPI::dmaWait(void)
+{
+  while (dmaBusy());
+}
+
+/***************************************************************************************
+** Function name:           pushPixelsDMA
+** Description:             Push pixels to TFT
+***************************************************************************************/
+void TFT_eSPI::pushPixelsDMA(uint16_t *image, uint32_t len)
+{
+  if ((len == 0) || (!DMA_Enabled)) return;
+  
+  if(_swapBytes) {
+    for (uint32_t i = 0; i < len; i++) (image[i] = image[i] << 8 | image[i] >> 8);
+  }
+  dmaWait();
+  zDMA.changeDescriptor(desc, image, (void *)&SERCOM0->SPI.DATA.reg, len * 2);
+  stat = zDMA.startJob();
+  spiBusyCheck = true;
+}
+
+/***************************************************************************************
+** Function name:           pushImageDMA
+** Description:             Push image to a window (w*h must be less than 65536)
+***************************************************************************************/
+// This will clip and also swap bytes if setSwapBytes(true) was called by sketch
+void TFT_eSPI::pushImageDMA(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t* image, uint16_t* buffer) 
+{
+  
+  if ((x >= _vpW) || (y >= _vpH)) return;
+
+  int32_t dx = 0;
+  int32_t dy = 0;
+  int32_t dw = w;
+  int32_t dh = h;
+
+  if (x < _vpX) { dx = _vpX - x; dw -= dx; x = _vpX; }
+  if (y < _vpY) { dy = _vpY - y; dh -= dy; y = _vpY; }
+
+  if ((x + dw) > _vpW ) dw = _vpW - x;
+  if ((y + dh) > _vpH ) dh = _vpH - y;
+
+  if (dw < 1 || dh < 1) return;
+
+  uint32_t len = dw*dh;
+  if (buffer == nullptr) {
+    buffer = image;
+  }
+
+  // If image is clipped, copy pixels into a contiguous block
+  if ( (dw != w) || (dh != h) ) {
+    if(_swapBytes) {
+      for (int32_t yb = 0; yb < dh; yb++) {
+        for (int32_t xb = 0; xb < dw; xb++) {
+          uint32_t src = xb + dx + w * (yb + dy);
+          (buffer[xb + yb * dw] = image[src] << 8 | image[src] >> 8);
+        }
+      }
+    }
+    else {
+      for (int32_t yb = 0; yb < dh; yb++) {
+        memcpy((uint8_t*) (buffer + yb * dw), (uint8_t*) (image + dx + w * (yb + dy)), dw << 1);
+      }
+    }
+  }
+  // else, if a buffer pointer has been provided copy whole image to the buffer
+  else if (buffer != image || _swapBytes) {
+    if(_swapBytes) {
+      for (uint32_t i = 0; i < len; i++) (buffer[i] = image[i] << 8 | image[i] >> 8);
+    }
+    else {
+      memcpy(buffer, image, len*2);
+    }
+  }
+  setWindow(x, y, x + dw - 1, y + dh - 1);
+  
+  const uint32_t DMA_MAX_TX_SIZE = 0x7fff;
+  while(len > DMA_MAX_TX_SIZE) {
+    dmaWait();
+    zDMA.changeDescriptor(desc, buffer, (void *)&SERCOM0->SPI.DATA.reg, DMA_MAX_TX_SIZE * 2);
+    stat = zDMA.startJob();
+    spiBusyCheck = true;
+    len -= DMA_MAX_TX_SIZE; 
+    buffer += DMA_MAX_TX_SIZE;
+  }
+  
+  dmaWait();
+  zDMA.changeDescriptor(desc, buffer, (void *)&SERCOM0->SPI.DATA.reg, len * 2);
+  stat=zDMA.startJob();
+  spiBusyCheck = true;
+}

--- a/Processors/TFT_eSPI_SAMD21.h
+++ b/Processors/TFT_eSPI_SAMD21.h
@@ -1,0 +1,173 @@
+        ////////////////////////////////////////////////////
+        //       TFT_eSPI XIAO_SAMD21 driver functions    //
+        ////////////////////////////////////////////////////
+
+
+#ifndef _TFT_eSPI_SAMD21H_
+#define _TFT_eSPI_SAMD21H_
+
+// Processor ID reported by getSetup()
+#define PROCESSOR_ID 0x21
+
+// Include processor specific header
+#include "SPI.h"
+#include "Adafruit_ZeroDMA.h"
+#include "utility/dma.h"
+
+#define SET_BUS_WRITE_MODE
+#define SET_BUS_READ_MODE
+
+#define SAMD21_DMA
+
+#define SPI_BUSY_CHECK spi.waitForTransfer();
+
+// Code to check if DMA is busy, used by SPI bus transaction startWrite and endWrite functions
+#define DMA_BUSY_CHECK dmaWait()
+
+// To be safe, SUPPORT_TRANSACTIONS is assumed mandatory
+#if !defined (SUPPORT_TRANSACTIONS)
+  #define SUPPORT_TRANSACTIONS
+#endif
+
+#define INIT_TFT_DATA_BUS
+
+#ifdef SMOOTH_FONT
+  // #define FS_NO_GLOBALS
+  #include <Seeed_Arduino_FS.h>
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the DC (TFT Data/Command or Register Select (RS))pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_DC
+  #define DC_C
+  #define DC_D
+#else
+  #define DC_C digitalPinToPort(TFT_DC)->OUTCLR.reg = digitalPinToBitMask(TFT_DC)
+  #define DC_D digitalPinToPort(TFT_DC)->OUTSET.reg = digitalPinToBitMask(TFT_DC)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the CS (TFT chip select) pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_CS
+  #define CS_L
+  #define CS_H
+#else
+  #define CS_L digitalPinToPort(TFT_CS)->OUTCLR.reg = digitalPinToBitMask(TFT_CS)
+  #define CS_H digitalPinToPort(TFT_CS)->OUTSET.reg = digitalPinToBitMask(TFT_CS)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Make sure TFT_RD is defined if not used to avoid an error message
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_RD
+  #define TFT_RD -1
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the WR (TFT Write) pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#ifdef TFT_WR
+  #define WR_L digitalPinToPort(TFT_WR)->OUTCLR.reg = digitalPinToBitMask(TFT_WR)
+  #define WR_H digitalPinToPort(TFT_WR)->OUTSET.reg = digitalPinToBitMask(TFT_WR)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the touch screen chip select pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#if !defined TOUCH_CS || (TOUCH_CS < 0)
+  #define T_CS_L
+  #define T_CS_H
+#else
+  #define T_CS_L digitalPinToPort(TOUCH_CS)->OUTCLR.reg = digitalPinToBitMask(TOUCH_CS)
+  #define T_CS_H digitalPinToPort(TOUCH_CS)->OUTSET.reg = digitalPinToBitMask(TOUCH_CS)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Make sure TFT_MISO is defined if not used to avoid an error message
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_MISO
+  #define TFT_MISO -1
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Macros to write commands/pixel colour data to a SPI ILI948x TFT
+////////////////////////////////////////////////////////////////////////////////////////
+#if defined (SPI_18BIT_DRIVER)
+
+  // Write 8 bits to TFT
+  #define tft_Write_8(C)   spi.transfer(C)
+  
+  // Convert 16-bit colour to 18-bit and write in 3 bytes
+  #define tft_Write_16(C)  spi.transfer(((C) & 0xF800)>>8); \
+                           spi.transfer(((C) & 0x07E0)>>3); \
+                           spi.transfer(((C) & 0x001F)<<3)
+
+  // Convert swapped byte 16-bit colour to 18-bit and write in 3 bytes
+  #define tft_Write_16S(C) spi.transfer((C) & 0xF8); \
+                           spi.transfer(((C) & 0xE000)>>11 | ((C) & 0x07)<<5); \
+                           spi.transfer(((C) & 0x1F00)>>5)
+  // Write 32 bits to TFT
+  #define tft_Write_32(C)  spi.transfer16((C)>>16); spi.transfer16((uint16_t)(C))
+
+  // Write two address coordinates
+  #define tft_Write_32C(C,D) spi.transfer16(C); spi.transfer16(D)
+
+// Write same value twice
+  #define tft_Write_32D(C) spi.transfer16(C); spi.transfer16(C)
+////////////////////////////////////////////////////////////////////////////////////////
+// Macros to write commands/pixel colour data to other displays
+////////////////////////////////////////////////////////////////////////////////////////
+#else
+  #if defined (RPI_DISPLAY_TYPE)
+    #define tft_Write_8(C)   spi.transfer(C); spi.transfer(C)
+    #define tft_Write_16(C)  spi.transfer((uint8_t)((C)>>8));spi.transfer((uint8_t)((C)>>0))
+    #define tft_Write_16S(C) spi.transfer((uint8_t)((C)>>0));spi.transfer((uint8_t)((C)>>8))
+    #define tft_Write_32(C) \
+      tft_Write_16((uint16_t) ((C)>>16)); \
+      tft_Write_16((uint16_t) ((C)>>0))
+    #define tft_Write_32C(C,D) \
+      spi.transfer(0); spi.transfer((C)>>8); \
+      spi.transfer(0); spi.transfer((C)>>0); \
+      spi.transfer(0); spi.transfer((D)>>8); \
+      spi.transfer(0); spi.transfer((D)>>0)
+    #define tft_Write_32D(C) \
+      spi.transfer(0); spi.transfer((C)>>8); \
+      spi.transfer(0); spi.transfer((C)>>0); \
+      spi.transfer(0); spi.transfer((C)>>8); \
+      spi.transfer(0); spi.transfer((C)>>0)
+  #else
+    #define tft_Write_8(C)   spi.transfer(C)
+    #define tft_Write_16(C)  spi.transfer16(C)
+    #define tft_Write_16S(C) spi.transfer16(((C)>>8) | ((C)<<8))
+    #define tft_Write_32(C) \
+      tft_Write_16((uint16_t) ((C)>>16)); \
+      tft_Write_16((uint16_t) ((C)>>0))
+    #define tft_Write_32C(C,D) \
+      tft_Write_16((uint16_t) (C)); \
+      tft_Write_16((uint16_t) (D))
+    #define tft_Write_32D(C) \
+      tft_Write_16((uint16_t) (C)); \
+      tft_Write_16((uint16_t) (C))
+  #endif
+#endif
+
+#ifndef tft_Write_16N
+  #define tft_Write_16N tft_Write_16
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Macros to read from display using SPI or software SPI
+////////////////////////////////////////////////////////////////////////////////////////
+#if defined (TFT_SDA_READ)
+  // Use a bit banged function call for STM32 and bi-directional SDA pin
+  #define TFT_eSPI_ENABLE_8_BIT_READ // Enable tft_Read_8(void);
+  #define SCLK_L digitalWrite(TFT_SCLK, LOW)
+  #define SCLK_H digitalWrite(TFT_SCLK, HIGH)
+#else
+  // Use a SPI read transfer
+  #define tft_Read_8() spi.transfer(0)
+#endif
+
+#endif // Header end

--- a/Processors/TFT_eSPI_nRF52840.c
+++ b/Processors/TFT_eSPI_nRF52840.c
@@ -1,0 +1,378 @@
+////////////////////////////////////////////////////
+//      TFT_eSPI XIAO_NRF52840 driver functions   //
+////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Global variables
+////////////////////////////////////////////////////////////////////////////////////////
+// Select the SPI port to use
+#ifdef TFT_SPI_PORT
+  SPIClass& spi = TFT_SPI_PORT;
+#else
+  SPIClass& spi = SPI;
+#endif
+
+#if defined (TFT_SDA_READ) && !defined (TFT_PARALLEL_8_BIT)
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           tft_Read_8
+** Description:             Bit bashed SPI to read bidirectional SDA line
+***************************************************************************************/
+uint8_t TFT_eSPI::tft_Read_8(void)
+{
+  uint8_t  ret = 0;
+
+  for (uint8_t i = 0; i < 8; i++) {  // read results
+    ret <<= 1;
+    SCLK_L;
+    if (digitalRead(TFT_MOSI)) ret |= 1;
+    SCLK_H;
+  }
+
+  return ret;
+}
+
+/***************************************************************************************
+** Function name:           beginSDA
+** Description:             Detach SPI from pin to permit software SPI
+***************************************************************************************/
+void TFT_eSPI::begin_SDA_Read(void)
+{
+  // Release configured SPI port for SDA read
+  spi.end();
+}
+
+/***************************************************************************************
+** Function name:           endSDA
+** Description:             Attach SPI pins after software SPI
+***************************************************************************************/
+void TFT_eSPI::end_SDA_Read(void)
+{
+  // Configure SPI port ready for next TFT access
+  spi.begin();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#endif // #if defined (TFT_SDA_READ)
+////////////////////////////////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+#if defined (TFT_PARALLEL_8_BIT) // Code for generic (i.e. any) processor
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for generic processor and parallel display
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
+
+  while (len>1) {tft_Write_32D(color); len-=2;}
+  if (len) {tft_Write_16(color);}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for gereric processor and parallel display
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
+
+  uint16_t *data = (uint16_t*)data_in;
+  if(_swapBytes) {
+    while (len>1) {tft_Write_16(*data); data++; tft_Write_16(*data); data++; len -=2;}
+    if (len) {tft_Write_16(*data);}
+    return;
+  }
+
+  while (len>1) {tft_Write_16S(*data); data++; tft_Write_16S(*data); data++; len -=2;}
+  if (len) {tft_Write_16S(*data);}
+}
+
+/***************************************************************************************
+** Function name:           GPIO direction control  - supports class functions
+** Description:             Set parallel bus to INPUT or OUTPUT
+***************************************************************************************/
+void TFT_eSPI::busDir(uint32_t mask, uint8_t mode)
+{
+  // mask is unused for generic processor
+  // Arduino native functions suited well to a generic driver
+  pinMode(TFT_D0, mode);
+  pinMode(TFT_D1, mode);
+  pinMode(TFT_D2, mode);
+  pinMode(TFT_D3, mode);
+  pinMode(TFT_D4, mode);
+  pinMode(TFT_D5, mode);
+  pinMode(TFT_D6, mode);
+  pinMode(TFT_D7, mode);
+  return;
+}
+
+/***************************************************************************************
+** Function name:           GPIO direction control  - supports class functions
+** Description:             Faster GPIO pin input/output switch
+***************************************************************************************/
+void TFT_eSPI::gpioMode(uint8_t gpio, uint8_t mode)
+{
+  // No fast port based generic approach available
+}
+
+/***************************************************************************************
+** Function name:           read byte  - supports class functions
+** Description:             Read a byte - parallel bus only
+***************************************************************************************/
+uint8_t TFT_eSPI::readByte(void)
+{
+  uint8_t b = 0;
+
+  busDir(0, INPUT);
+  digitalWrite(TFT_RD, LOW);
+
+  b |= digitalRead(TFT_D0) << 0;
+  b |= digitalRead(TFT_D1) << 1;
+  b |= digitalRead(TFT_D2) << 2;
+  b |= digitalRead(TFT_D3) << 3;
+  b |= digitalRead(TFT_D4) << 4;
+  b |= digitalRead(TFT_D5) << 5;
+  b |= digitalRead(TFT_D6) << 6;
+  b |= digitalRead(TFT_D7) << 7;
+
+  digitalWrite(TFT_RD, HIGH);
+  busDir(0, OUTPUT);
+
+  return b;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#elif defined (RPI_WRITE_STROBE)  // For RPi TFT with write strobe                      
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for ESP32 or STM32 RPi TFT
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
+
+  if(len) { tft_Write_16(color); len--; }
+  while(len--) {WR_L; WR_H;}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for ESP32 or STM32 RPi TFT
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len)
+{
+  uint16_t *data = (uint16_t*)data_in;
+
+  if (_swapBytes) while ( len-- ) {tft_Write_16S(*data); data++;}
+  else while ( len-- ) {tft_Write_16(*data); data++;}
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#elif defined (SPI_18BIT_DRIVER) // SPI 18-bit colour                         
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for STM32 and 3 byte RGB display
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len)
+{
+  // Split out the colours
+  uint8_t r = (color & 0xF800)>>8;
+  uint8_t g = (color & 0x07E0)>>3;
+  uint8_t b = (color & 0x001F)<<3;
+
+  while ( len-- ) {tft_Write_8(r); tft_Write_8(g); tft_Write_8(b);}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for STM32 and 3 byte RGB display
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
+
+  uint16_t *data = (uint16_t*)data_in;
+  if (_swapBytes) {
+    while ( len-- ) {
+      uint16_t color = *data >> 8 | *data << 8;
+      tft_Write_8((color & 0xF800)>>8);
+      tft_Write_8((color & 0x07E0)>>3);
+      tft_Write_8((color & 0x001F)<<3);
+      data++;
+    }
+  }
+  else {
+    while ( len-- ) {
+      tft_Write_8((*data & 0xF800)>>8);
+      tft_Write_8((*data & 0x07E0)>>3);
+      tft_Write_8((*data & 0x001F)<<3);
+      data++;
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#else //                   Standard SPI 16-bit colour TFT                               
+////////////////////////////////////////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           pushBlock - for STM32
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
+
+  while ( len-- ) {tft_Write_16(color);}
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for STM32
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
+
+  uint16_t *data = (uint16_t*)data_in;
+
+  if (_swapBytes) while ( len-- ) {tft_Write_16(*data); data++;}
+  else while ( len-- ) {tft_Write_16S(*data); data++;}
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#endif // End of display interface specific functions
+////////////////////////////////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+#ifdef NRF52840_DMA // DMA functions for 16-bit SPI and 8/16-bit parallel displays
+////////////////////////////////////////////////////////////////////////////////////////
+
+bool DMA_Enabled = false;
+
+/***************************************************************************************
+** Function name:           dmaBusy
+** Description:             Check if DMA is busy (usefully non-blocking!)
+***************************************************************************************/
+// Use while( tft.dmaBusy() ) {Do-something-useful;}"
+bool TFT_eSPI::dmaBusy(void) {
+  return NRF_SPIM0->EVENTS_ENDTX; 
+}
+
+/***************************************************************************************
+** Function name:           dmaWait
+** Description:             Wait until DMA is over (blocking!)
+***************************************************************************************/
+void TFT_eSPI::dmaWait(void)
+{
+  while (dmaBusy());
+}
+
+/***************************************************************************************
+** Function name:           pushPixelsDMA
+** Description:             Push pixels to TFT
+***************************************************************************************/
+void TFT_eSPI::pushPixelsDMA(uint16_t *image, uint32_t len)
+{
+  if (!DMA_Enabled || len == 0) return;
+  
+  if(_swapBytes) {
+    for (uint32_t i = 0; i < len; i++) (image[i] = image[i] << 8 | image[i] >> 8);
+  }
+
+  dmaWait();
+  spi.transfer(image, len * 2);
+}
+
+/***************************************************************************************
+** Function name:           pushImageDMA
+** Description:             Push image to a window (w*h must be less than 65536)
+***************************************************************************************/
+// This will clip and also swap bytes if setSwapBytes(true) was called by sketch
+void TFT_eSPI::pushImageDMA(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t* image, uint16_t* buffer) 
+{
+  if ((x >= _vpW) || (y >= _vpH)) return;
+
+  int32_t dx = 0;
+  int32_t dy = 0;
+  int32_t dw = w;
+  int32_t dh = h;
+
+  if (x < _vpX) { dx = _vpX - x; dw -= dx; x = _vpX; }
+  if (y < _vpY) { dy = _vpY - y; dh -= dy; y = _vpY; }
+
+  if ((x + dw) > _vpW ) dw = _vpW - x;
+  if ((y + dh) > _vpH ) dh = _vpH - y;
+
+  if (dw < 1 || dh < 1) return;
+
+  uint32_t len = dw*dh;
+
+  if (buffer == nullptr) {
+    buffer = image;
+    dmaWait();
+  }
+
+  // If image is clipped, copy pixels into a contiguous block
+  if ( (dw != w) || (dh != h) ) {
+    if(_swapBytes) {
+      for (int32_t yb = 0; yb < dh; yb++) {
+        for (int32_t xb = 0; xb < dw; xb++) {
+          uint32_t src = xb + dx + w * (yb + dy);
+          (buffer[xb + yb * dw] = image[src] << 8 | image[src] >> 8);
+        }
+      }
+    }
+    else {
+      for (int32_t yb = 0; yb < dh; yb++) {
+        memcpy((uint8_t*) (buffer + yb * dw), (uint8_t*) (image + dx + w * (yb + dy)), dw << 1);
+      }
+    }
+  }
+  // else, if a buffer pointer has been provided copy whole image to the buffer
+  else if (buffer != image || _swapBytes) {
+    if(_swapBytes) {
+      for (uint32_t i = 0; i < len; i++) (buffer[i] = image[i] << 8 | image[i] >> 8);
+    }
+    else {
+      memcpy(buffer, image, len*2);
+    }
+  }
+
+  setWindow(x, y, x + dw - 1, y + dh - 1);
+
+  const uint32_t DMA_MAX_TX_SIZE = 0x7fff;
+  while(len>DMA_MAX_TX_SIZE) { // Transfer 16-bit pixels in blocks if len*2 over 65534 bytes
+    dmaWait();
+    spi.transfer((uint16_t*)buffer, DMA_MAX_TX_SIZE * 2);
+    len -= DMA_MAX_TX_SIZE; buffer+= DMA_MAX_TX_SIZE; // Arbitrarily send 1K pixel blocks (2Kbytes)
+  }
+  dmaWait();
+  // Send remaining pixels using DMA (max 65534 bytes)
+  spi.transfer((uint16_t*)buffer, len * 2);
+   
+}
+
+/***************************************************************************************
+** Function name:           initDMA
+** Description:             Initialise the DMA engine - returns true if init OK
+***************************************************************************************/
+bool TFT_eSPI::initDMA(bool ctrl_cs) {
+  if (DMA_Enabled) return false;
+
+  DMA_Enabled = true;
+  return true;
+}
+  
+/***************************************************************************************
+** Function name:           deInitDMA
+** Description:             Disconnect the DMA engine from SPI
+***************************************************************************************/
+void TFT_eSPI::deInitDMA(void)
+{
+  if (!DMA_Enabled) return;
+  DMA_Enabled = false;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+#endif // End of DMA FUNCTIONS
+////////////////////////////////////////////////////////////////////////////////////////

--- a/Processors/TFT_eSPI_nRF52840.h
+++ b/Processors/TFT_eSPI_nRF52840.h
@@ -1,0 +1,172 @@
+        ////////////////////////////////////////////////////
+        //      TFT_eSPI XIAO_NRF52840 driver functions   //
+        ////////////////////////////////////////////////////
+
+
+#ifndef _TFT_eSPI_NRF52840H_
+#define _TFT_eSPI_NRF52840H_
+
+// Processor ID reported by getSetup()
+#define PROCESSOR_ID 0x21
+
+// Include processor specific header
+#include "SPI.h"
+
+#define SET_BUS_WRITE_MODE
+#define SET_BUS_READ_MODE
+
+#define NRF52840_DMA
+
+// #define SPI_BUSY_CHECK spi.waitForTransfer();
+
+
+// Code to check if DMA is busy, used by SPI bus transaction startWrite and endWrite functions
+#define DMA_BUSY_CHECK dmaWait()
+
+// To be safe, SUPPORT_TRANSACTIONS is assumed mandatory
+#if !defined (SUPPORT_TRANSACTIONS)
+  #define SUPPORT_TRANSACTIONS
+#endif
+
+#define INIT_TFT_DATA_BUS
+
+#ifdef SMOOTH_FONT
+  // #define FS_NO_GLOBALS
+  #include <Seeed_Arduino_FS.h>
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the DC (TFT Data/Command or Register Select (RS))pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_DC
+  #define DC_C // No macro allocated so it generates no code
+  #define DC_D // No macro allocated so it generates no code
+#else
+  #define DC_C digitalWrite(TFT_DC, LOW)
+  #define DC_D digitalWrite(TFT_DC, HIGH)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the CS (TFT chip select) pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_CS
+  #define CS_L // No macro allocated so it generates no code
+  #define CS_H // No macro allocated so it generates no code
+#else
+  #define CS_L digitalWrite(TFT_CS, LOW)
+  #define CS_H digitalWrite(TFT_CS, HIGH)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Make sure TFT_RD is defined if not used to avoid an error message
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_RD
+  #define TFT_RD -1
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the WR (TFT Write) pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#ifdef TFT_WR
+  #define WR_L digitalWrite(TFT_WR, LOW)
+  #define WR_H digitalWrite(TFT_WR, HIGH)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the touch screen chip select pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#if !defined TOUCH_CS || (TOUCH_CS < 0)
+  #define T_CS_L // No macro allocated so it generates no code
+  #define T_CS_H // No macro allocated so it generates no code
+#else
+  #define T_CS_L digitalWrite(TOUCH_CS, LOW)
+  #define T_CS_H digitalWrite(TOUCH_CS, HIGH)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Make sure TFT_MISO is defined if not used to avoid an error message
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_MISO
+  #define TFT_MISO -1
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Macros to write commands/pixel colour data to a SPI ILI948x TFT
+////////////////////////////////////////////////////////////////////////////////////////
+#if defined (SPI_18BIT_DRIVER)
+
+  // Write 8 bits to TFT
+  #define tft_Write_8(C)   spi.transfer(C)
+  
+  // Convert 16-bit colour to 18-bit and write in 3 bytes
+  #define tft_Write_16(C)  spi.transfer(((C) & 0xF800)>>8); \
+                           spi.transfer(((C) & 0x07E0)>>3); \
+                           spi.transfer(((C) & 0x001F)<<3)
+
+  // Convert swapped byte 16-bit colour to 18-bit and write in 3 bytes
+  #define tft_Write_16S(C) spi.transfer((C) & 0xF8); \
+                           spi.transfer(((C) & 0xE000)>>11 | ((C) & 0x07)<<5); \
+                           spi.transfer(((C) & 0x1F00)>>5)
+  // Write 32 bits to TFT
+  #define tft_Write_32(C)  spi.transfer16((C)>>16); spi.transfer16((uint16_t)(C))
+
+  // Write two address coordinates
+  #define tft_Write_32C(C,D) spi.transfer16(C); spi.transfer16(D)
+
+// Write same value twice
+  #define tft_Write_32D(C) spi.transfer16(C); spi.transfer16(C)
+////////////////////////////////////////////////////////////////////////////////////////
+// Macros to write commands/pixel colour data to other displays
+////////////////////////////////////////////////////////////////////////////////////////
+#else
+  #if defined (RPI_DISPLAY_TYPE)
+    #define tft_Write_8(C)   spi.transfer(C); spi.transfer(C)
+    #define tft_Write_16(C)  spi.transfer((uint8_t)((C)>>8));spi.transfer((uint8_t)((C)>>0))
+    #define tft_Write_16S(C) spi.transfer((uint8_t)((C)>>0));spi.transfer((uint8_t)((C)>>8))
+    #define tft_Write_32(C) \
+      tft_Write_16((uint16_t) ((C)>>16)); \
+      tft_Write_16((uint16_t) ((C)>>0))
+    #define tft_Write_32C(C,D) \
+      spi.transfer(0); spi.transfer((C)>>8); \
+      spi.transfer(0); spi.transfer((C)>>0); \
+      spi.transfer(0); spi.transfer((D)>>8); \
+      spi.transfer(0); spi.transfer((D)>>0)
+    #define tft_Write_32D(C) \
+      spi.transfer(0); spi.transfer((C)>>8); \
+      spi.transfer(0); spi.transfer((C)>>0); \
+      spi.transfer(0); spi.transfer((C)>>8); \
+      spi.transfer(0); spi.transfer((C)>>0)
+  #else
+    #define tft_Write_8(C)   spi.transfer(C)
+    #define tft_Write_16(C)  spi.transfer16(C)
+    #define tft_Write_16S(C) spi.transfer16(((C)>>8) | ((C)<<8))
+    #define tft_Write_32(C) \
+      tft_Write_16((uint16_t) ((C)>>16)); \
+      tft_Write_16((uint16_t) ((C)>>0))
+    #define tft_Write_32C(C,D) \
+      tft_Write_16((uint16_t) (C)); \
+      tft_Write_16((uint16_t) (D))
+    #define tft_Write_32D(C) \
+      tft_Write_16((uint16_t) (C)); \
+      tft_Write_16((uint16_t) (C))
+  #endif
+#endif
+
+#ifndef tft_Write_16N
+  #define tft_Write_16N tft_Write_16
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Macros to read from display using SPI or software SPI
+////////////////////////////////////////////////////////////////////////////////////////
+#if defined (TFT_SDA_READ)
+  // Use a bit banged function call for STM32 and bi-directional SDA pin
+  #define TFT_eSPI_ENABLE_8_BIT_READ // Enable tft_Read_8(void);
+  #define SCLK_L digitalWrite(TFT_SCLK, LOW)
+  #define SCLK_H digitalWrite(TFT_SCLK, HIGH)
+#else
+  // Use a SPI read transfer
+  #define tft_Read_8() spi.transfer(0)
+#endif
+
+#endif // Header end

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -29,6 +29,14 @@
   #include "Processors/TFT_eSPI_STM32.c"
 #elif defined (ARDUINO_ARCH_RP2040)  || defined (ARDUINO_ARCH_MBED) && !defined(ARDUINO_ARCH_NRF52840)// Raspberry Pi Pico
   #include "Processors/TFT_eSPI_RP2040.c"
+#elif defined(SEEED_XIAO_M0)
+  #include "Processors/TFT_eSPI_SAMD21.c"
+#elif defined(ARDUINO_XIAO_RA4M1)
+  #include "Processors/TFT_eSPI_RA4M1.c"
+#elif defined(NRF52840_XXAA)
+  #include "Processors/TFT_eSPI_NRF52840.c"
+#elif defined (EFR32MG24B220F1536IM48)
+  #include "Processors/TFT_eSPI_MG24.cpp"
 #else
   #include "Processors/TFT_eSPI_Generic.c"
 #endif
@@ -614,7 +622,7 @@ void TFT_eSPI::init(uint8_t tc)
   {
     initBus();
 
-#if !defined (ESP32) && !defined(TFT_PARALLEL_8_BIT) && !defined(ARDUINO_ARCH_RP2040) && !defined (ARDUINO_ARCH_MBED)
+#if !defined (ESP32) && !defined(TFT_PARALLEL_8_BIT) && !defined(ARDUINO_ARCH_RP2040) && !defined (ARDUINO_ARCH_MBED) && !defined (EFR32MG24B220F1536IM48)
   // Legacy bitmasks for GPIO
   #if defined (TFT_CS) && (TFT_CS >= 0)
     cspinmask = (uint32_t) digitalPinToBitMask(TFT_CS);
@@ -643,7 +651,7 @@ void TFT_eSPI::init(uint8_t tc)
 
 #else
   #if !defined(TFT_PARALLEL_8_BIT) && !defined(RP2040_PIO_INTERFACE)
-    #if defined (TFT_MOSI) && !defined (TFT_SPI_OVERLAP) && !defined(ARDUINO_ARCH_RP2040) && !defined (ARDUINO_ARCH_MBED)
+    #if defined (TFT_MOSI) && !defined (TFT_SPI_OVERLAP) && !defined(ARDUINO_ARCH_RP2040) && !defined (ARDUINO_ARCH_MBED) && !defined (EFR32MG24B220F1536IM48)
       spi.begin(TFT_SCLK, TFT_MISO, TFT_MOSI, -1); // This will set MISO to input
     #else
       spi.begin(); // This will set MISO to input

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -6167,7 +6167,7 @@ void TFT_eSPI::getSetup(setup_t &tft_settings)
 #include "Touch_Drivers/Touch.cpp"
 
 #ifdef GDEM075T7_DRIVER
-#include "Extensions/Epaper.cpp"
+#include "Extensions/EPaper.cpp"
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -105,6 +105,14 @@
 #include "Processors/TFT_eSPI_STM32.h"
 #elif defined(ARDUINO_ARCH_RP2040)
 #include "Processors/TFT_eSPI_RP2040.h"
+#elif defined(SEEED_XIAO_M0)
+  #include "Processors/TFT_eSPI_SAMD21.h"
+#elif defined(ARDUINO_XIAO_RA4M1)
+  #include "Processors/TFT_eSPI_RA4M1.h"
+#elif defined(NRF52840_XXAA)
+  #include "Processors/TFT_eSPI_nRF52840.h"
+#elif defined (EFR32MG24B220F1536IM48)
+  #include "Processors/TFT_eSPI_MG24.h"
 #else
 #include "Processors/TFT_eSPI_Generic.h"
 #define GENERIC_PROCESSOR

--- a/Touch_Drivers/CHSCX6X.cpp
+++ b/Touch_Drivers/CHSCX6X.cpp
@@ -1,7 +1,7 @@
 bool TFT_eSPI::getTouch(int32_t *x, int32_t *y, uint16_t threshold)
 {
 
-  int32_t _x, _y;
+  int32_t _x = 0, _y = 0;
   uint8_t temp[CHSC6X_READ_POINT_LEN] = {0};
   uint8_t read_len = Wire.requestFrom(CHSC6X_I2C_ID, CHSC6X_READ_POINT_LEN);
 
@@ -66,4 +66,30 @@ bool TFT_eSPI::getTouch(int32_t *x, int32_t *y, uint16_t threshold)
   *y = *y - _yDatum;
 
   return true;
+}
+
+bool TFT_eSPI::getTouchRaw(int32_t *x, int32_t *y)
+{
+#pragma warning "This function is obsolete and is only implemented empty to maintain compatibility"
+  return false;
+}
+
+uint16_t TFT_eSPI::getTouchRawZ(void)
+{
+#pragma warning "This function is obsolete and is only implemented empty to maintain compatibility"
+  return 0;
+}
+
+void TFT_eSPI::convertRawXY(int32_t *x, int32_t *y)
+{
+#pragma warning "This function is obsolete and is only implemented empty to maintain compatibility"
+}
+void TFT_eSPI::calibrateTouch(uint16_t *data, uint32_t color_fg, uint32_t color_bg, uint8_t size)
+{
+#pragma warning "This function is obsolete and is only implemented empty to maintain compatibility"
+}
+
+void TFT_eSPI::setTouch(uint16_t *data)
+{
+#pragma warning "This function is obsolete and is only implemented empty to maintain compatibility"
 }

--- a/Touch_Drivers/CHSCX6X.h
+++ b/Touch_Drivers/CHSCX6X.h
@@ -1,3 +1,10 @@
 public:
 
   bool  getTouch(int32_t *x, int32_t *y, uint16_t threshold = 600);
+
+  /*Considering the capacitive screen implementation, the following functions are obsolete and are only implemented empty to maintain compatibility*/
+  bool getTouchRaw(int32_t *x, int32_t *y);
+  uint16_t getTouchRawZ(void);
+  void convertRawXY(int32_t *x, int32_t *y);
+  void calibrateTouch(uint16_t *data, uint32_t color_fg, uint32_t color_bg, uint8_t size);
+  void setTouch(uint16_t *data);

--- a/Touch_Drivers/Touch.cpp
+++ b/Touch_Drivers/Touch.cpp
@@ -5,4 +5,25 @@ bool TFT_eSPI::getTouch(int32_t *x, int32_t *y, uint16_t threshold)
 {
     return false;
 }
+
+bool TFT_eSPI::getTouchRaw(int32_t *x, int32_t *y)
+{
+    return false;
+}
+
+uint16_t TFT_eSPI::getTouchRawZ(void)
+{
+    return 0;
+}
+
+void TFT_eSPI::convertRawXY(int32_t *x, int32_t *y)
+{
+}
+void TFT_eSPI::calibrateTouch(uint16_t *data, uint32_t color_fg, uint32_t color_bg, uint8_t size)
+{
+}
+
+void TFT_eSPI::setTouch(uint16_t *data)
+{
+}
 #endif

--- a/Touch_Drivers/Touch.h
+++ b/Touch_Drivers/Touch.h
@@ -2,5 +2,16 @@
 #include "Touch_Drivers/CHSCX6X.h"
 #else
 public:
-  bool  getTouch(int32_t *x, int32_t *y, uint16_t threshold = 600);
+bool getTouchRaw(int32_t *x, int32_t *y);
+
+uint16_t getTouchRawZ(void);
+
+void convertRawXY(int32_t *x, int32_t *y);
+
+bool getTouch(int32_t *x, int32_t *y, uint16_t threshold = 600);
+
+void calibrateTouch(uint16_t *data, uint32_t color_fg, uint32_t color_bg, uint8_t size);
+
+void setTouch(uint16_t *data);
+
 #endif

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -162,14 +162,14 @@
 #include <User_Setups/Setup500_Seeed_Wio_Terminal.h>     // Setup file for Seeed Wio Terimal with SPI ILI9341 320x240
 #else
 #include <User_Setups/Setup501_Seeed_XIAO_Round_Display.h>     // Setup file for Seeed XIAO ROUND with GC9A01 240 x 240
-#include <User_Setups/Setup502_Seeed_XIAO_EPaper_7inch5.h>     // Setup file for Seeed XIAO ROUND with GC9A01 240 x 240
+// #include <User_Setups/Setup502_Seeed_XIAO_EPaper_7inch5.h>     // Setup file for Seeed XIAO ROUND with GC9A01 240 x 240
 #endif
 
 
 #endif // USER_SETUP_LOADED
 
 // Compatible with some examples 
-#include "TFT_Drivers/ILI9341_Defines.h" 
+// #include "TFT_Drivers/ILI9341_Defines.h" 
 #ifdef NRF52840_XXAA
 #include <avr/dtostrf.h>
 #endif

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -162,13 +162,17 @@
 #include <User_Setups/Setup500_Seeed_Wio_Terminal.h>     // Setup file for Seeed Wio Terimal with SPI ILI9341 320x240
 #else
 #include <User_Setups/Setup501_Seeed_XIAO_Round_Display.h>     // Setup file for Seeed XIAO ROUND with GC9A01 240 x 240
-//#include <User_Setups/Setup502_Seeed_XIAO_ePaper_7inch5.h>     // Setup file for Seeed XIAO ROUND with GC9A01 240 x 240
+#include <User_Setups/Setup502_Seeed_XIAO_EPaper_7inch5.h>     // Setup file for Seeed XIAO ROUND with GC9A01 240 x 240
 #endif
 
 
 #endif // USER_SETUP_LOADED
 
-
+// Compatible with some examples 
+#include "TFT_Drivers/ILI9341_Defines.h" 
+#ifdef NRF52840_XXAA
+#include <avr/dtostrf.h>
+#endif
 
 /////////////////////////////////////////////////////////////////////////////////////
 //                                                                                 //

--- a/User_Setups/Setup501_Seeed_XIAO_Round_Display.h
+++ b/User_Setups/Setup501_Seeed_XIAO_Round_Display.h
@@ -58,8 +58,11 @@
 #elif defined(ARDUINO_XIAO_RA4M1)
 #define SPI_FREQUENCY 25000000
 #define SPI_READ_FREQUENCY 4000000
+#elif defined (EFR32MG24B220F1536IM48)
+#define SPI_FREQUENCY 25000000
+#define SPI_READ_FREQUENCY 4000000
 #else
-#message "Unknown board using default SPI settings (25MHz)"
+#pragma message "Unknown board using default SPI settings (25MHz)"
 #define SPI_FREQUENCY 25000000
 #define SPI_READ_FREQUENCY 4000000
 #endif

--- a/examples/320 x 240/Keypad_240x320/Keypad_240x320.ino
+++ b/examples/320 x 240/Keypad_240x320/Keypad_240x320.ino
@@ -14,7 +14,11 @@
 // The SPIFFS (FLASH filing system) is used to hold touch screen
 // calibration data
 
+#if defined(SEEED_XIAO_M0) || defined(ARDUINO_XIAO_RA4M1) || defined(NRF52840_XXAA)
+#include <Seeed_Arduino_FS.h>
+#else
 #include "FS.h"
+#endif
 
 #include <SPI.h>
 #include <TFT_eSPI.h>      // Hardware-specific library
@@ -105,7 +109,7 @@ void setup() {
 //------------------------------------------------------------------------------------------
 
 void loop(void) {
-  uint16_t t_x = 0, t_y = 0; // To store the touch coordinates
+  int32_t t_x = 0, t_y = 0; // To store the touch coordinates
 
   // Pressed will be set true is there is a valid touch on the screen
   bool pressed = tft.getTouch(&t_x, &t_y);

--- a/examples/320 x 240/Read_ID_bitbash/Read_ID_bitbash.ino
+++ b/examples/320 x 240/Read_ID_bitbash/Read_ID_bitbash.ino
@@ -11,6 +11,11 @@
 
 // Change the pin settings to suit your hardware
 
+
+#ifdef NRF52840_XXAA
+#include <Adafruit_TinyUSB.h>
+#endif
+
 // UNO etc.
 //#define TFT_MOSI  11
 //#define TFT_SCK 13

--- a/examples/320 x 240/TFT_Pie_Chart/TFT_Pie_Chart.ino
+++ b/examples/320 x 240/TFT_Pie_Chart/TFT_Pie_Chart.ino
@@ -46,7 +46,7 @@ void loop() {
 // r = radius
 // colour = 16-bit colour value
 
-int fillSegment(int x, int y, int start_angle, int sub_angle, int r, unsigned int colour)
+void fillSegment(int x, int y, int start_angle, int sub_angle, int r, unsigned int colour)
 {
   // Calculate first pair of coordinates for segment start
   float sx = cos((start_angle - 90) * DEG2RAD);

--- a/examples/480 x 320/Keypad_480x320/Keypad_480x320.ino
+++ b/examples/480 x 320/Keypad_480x320/Keypad_480x320.ino
@@ -17,7 +17,11 @@
 // The SPIFFS (FLASH filing system) is used to hold touch screen
 // calibration data
 
+#if defined(SEEED_XIAO_M0) || defined(ARDUINO_XIAO_RA4M1) || defined(NRF52840_XXAA)
+#include <Seeed_Arduino_FS.h>
+#else
 #include "FS.h"
+#endif
 
 #include <SPI.h>
 #include <TFT_eSPI.h>      // Hardware-specific library
@@ -108,7 +112,7 @@ void setup() {
 //------------------------------------------------------------------------------------------
 
 void loop(void) {
-  uint16_t t_x = 0, t_y = 0; // To store the touch coordinates
+  int32_t t_x = 0, t_y = 0; // To store the touch coordinates
 
   // Pressed will be set true is there is a valid touch on the screen
   bool pressed = tft.getTouch(&t_x, &t_y);

--- a/examples/480 x 320/Touch_Controller_Demo/Touch_Controller_Demo.ino
+++ b/examples/480 x 320/Touch_Controller_Demo/Touch_Controller_Demo.ino
@@ -1,4 +1,8 @@
+#if defined(SEEED_XIAO_M0) || defined(ARDUINO_XIAO_RA4M1) || defined(NRF52840_XXAA)
+#include <Seeed_Arduino_FS.h>
+#else
 #include "FS.h"
+#endif
 #include <SPI.h>
 #include <TFT_eSPI.h>
 TFT_eSPI tft = TFT_eSPI();
@@ -57,7 +61,7 @@ void setup(void) {
 }
 
 void loop() {
-  uint16_t x, y;
+  int32_t x, y;
   static uint16_t color;
 
   if (tft.getTouch(&x, &y)) {

--- a/examples/GUI Widgets/Buttons/Button_demo/Button_demo.ino
+++ b/examples/GUI Widgets/Buttons/Button_demo/Button_demo.ino
@@ -3,7 +3,11 @@
 // Requires widget library here:
 // https://github.com/Bodmer/TFT_eWidget
 
-#include <FS.h>
+#if defined(SEEED_XIAO_M0) || defined(ARDUINO_XIAO_RA4M1) || defined(NRF52840_XXAA)
+#include <Seeed_Arduino_FS.h>
+#else
+#include "FS.h"
+#endif
 #include "Free_Fonts.h" // Include the header file attached to this sketch
 
 #include <TFT_eSPI.h>              // Hardware-specific library
@@ -102,7 +106,7 @@ void setup() {
 
 void loop() {
   static uint32_t scanTime = millis();
-  uint16_t t_x = 9999, t_y = 9999; // To store the touch coordinates
+  int32_t t_x = 9999, t_y = 9999; // To store the touch coordinates
 
   // Scan keys every 50ms at most
   if (millis() - scanTime >= 50) {

--- a/examples/GUI Widgets/Sliders/Slider_demo/Slider_demo.ino
+++ b/examples/GUI Widgets/Sliders/Slider_demo/Slider_demo.ino
@@ -3,7 +3,11 @@
 // Requires widget library here:
 // https://github.com/Bodmer/TFT_eWidget
 
+#if defined(SEEED_XIAO_M0) || defined(ARDUINO_XIAO_RA4M1) || defined(NRF52840_XXAA)
+#include <Seeed_Arduino_FS.h>
+#else
 #include "FS.h"
+#endif
 
 #include "Free_Fonts.h" // Include the header file attached to this sketch
 
@@ -109,7 +113,7 @@ void setup() {
 
 void loop() {
   static uint32_t scanTime = millis();
-  uint16_t t_x = 9999, t_y = 9999; // To store the touch coordinates
+  int32_t t_x = 9999, t_y = 9999; // To store the touch coordinates
 
   // Scan for touch every 50ms
   if (millis() - scanTime >= 20) {

--- a/examples/Generic/On_Off_Button/On_Off_Button.ino
+++ b/examples/Generic/On_Off_Button/On_Off_Button.ino
@@ -10,7 +10,11 @@
 // the TFT_eSPI library.
 
 // Calibration data is stored in SPIFFS so we need to include it
+#if defined(SEEED_XIAO_M0) || defined(ARDUINO_XIAO_RA4M1) || defined(NRF52840_XXAA)
+#include <Seeed_Arduino_FS.h>
+#else
 #include "FS.h"
+#endif
 
 #include <SPI.h>
 
@@ -73,7 +77,7 @@ void setup(void)
 //------------------------------------------------------------------------------------------
 void loop()
 {
-  uint16_t x, y;
+  int32_t x, y;
 
   // See if there's any touch data for us
   if (tft.getTouch(&x, &y))

--- a/examples/Generic/TFT_Button_Label_Datum/TFT_Button_Label_Datum.ino
+++ b/examples/Generic/TFT_Button_Label_Datum/TFT_Button_Label_Datum.ino
@@ -9,8 +9,11 @@
 
   Adjust the definitions below according to your screen size
 */
-
+#if defined(SEEED_XIAO_M0) || defined(ARDUINO_XIAO_RA4M1) || defined(NRF52840_XXAA)
+#include <Seeed_Arduino_FS.h>
+#else
 #include "FS.h"
+#endif
 
 #include <SPI.h>
 
@@ -70,7 +73,7 @@ void setup() {
 }
 
 void loop() {
-  uint16_t t_x = 0, t_y = 0; // To store the touch coordinates
+  int32_t t_x = 0, t_y = 0; // To store the touch coordinates
 
   // Get current touch state and coordinates
   bool pressed = tft.getTouch(&t_x, &t_y);

--- a/examples/Generic/Touch_calibrate/Touch_calibrate.ino
+++ b/examples/Generic/Touch_calibrate/Touch_calibrate.ino
@@ -41,7 +41,7 @@ void setup() {
 //------------------------------------------------------------------------------------------
 
 void loop(void) {
-  uint16_t x = 0, y = 0; // To store the touch coordinates
+  int32_t x = 0, y = 0; // To store the touch coordinates
 
   // Pressed will be set true is there is a valid touch on the screen
   bool pressed = tft.getTouch(&x, &y);

--- a/examples/Round Display/GifPlayer/GifPlayer.ino
+++ b/examples/Round Display/GifPlayer/GifPlayer.ino
@@ -1,11 +1,7 @@
 #include <vector>
 #include <TFT_eSPI.h>
 #include <SPI.h>
-#if defined(SEEED_XIAO_M0) || defined(ARDUINO_XIAO_RA4M1) || defined(NRF52840_XXAA)
-#include <Seeed_Arduino_FS.h>
-#else
 #include <SD.h>
-#endif
 #include <string>
 
 #include "AnimatedGIF.h"

--- a/examples/Round Display/GifPlayer/GifPlayer.ino
+++ b/examples/Round Display/GifPlayer/GifPlayer.ino
@@ -1,7 +1,12 @@
 #include <vector>
 #include <TFT_eSPI.h>
 #include <SPI.h>
+#if defined(SEEED_XIAO_M0) || defined(ARDUINO_XIAO_RA4M1) || defined(NRF52840_XXAA)
+#include <Seeed_Arduino_FS.h>
+#else
 #include <SD.h>
+#endif
+#include <string>
 
 #include "AnimatedGIF.h"
 
@@ -215,7 +220,7 @@ int getGifInventory( const char* basePath )
 
   while( file ) {
     if(!file.isDirectory()) {
-      GifFiles.push_back( file.name() );
+      GifFiles.push_back(std::string(file.name()));
       amount++;
       tft.drawString(String(amount), textPosX, textPosY );
       file.close();

--- a/examples/Smooth Fonts/LittleFS/Print_Smooth_Font/Print_Smooth_Font.ino
+++ b/examples/Smooth Fonts/LittleFS/Print_Smooth_Font/Print_Smooth_Font.ino
@@ -121,13 +121,27 @@ void loop() {
 void listFiles(void) {
   Serial.println();
   Serial.println("Flash FS files found:");
-
-  fs::Dir dir = LittleFS.openDir("/"); // Root directory
   String  line = "=====================================";
 
   Serial.println(line);
   Serial.println("  File name               Size");
   Serial.println(line);
+#ifdef ESP32 // LittleFS is implemented in a different way on ESP32
+  File dir = LittleFS.open("/"); // Root directory
+  File f = dir.openNextFile(); 
+
+  while (f) {
+    String fileName = f.name(); 
+    Serial.print(fileName);
+    int spaces = 25 - fileName.length(); // Tabulate nicely
+    if (spaces < 0) spaces = 1;
+    while (spaces--) Serial.print(" ");
+    Serial.print(f.size()); Serial.println(" bytes"); 
+    f = dir.openNextFile(); 
+    yield();
+  }
+#else
+  fs::Dir dir = LittleFS.openDir("/"); // Root directory
 
   while (dir.next()) {
     String fileName = dir.fileName();
@@ -139,6 +153,7 @@ void listFiles(void) {
     Serial.print(f.size()); Serial.println(" bytes");
     yield();
   }
+ #endif
 
   Serial.println(line);
 

--- a/examples/Smooth Fonts/LittleFS/Unicode_test/LittleFS_functions.ino
+++ b/examples/Smooth Fonts/LittleFS/Unicode_test/LittleFS_functions.ino
@@ -11,13 +11,27 @@
 void listFiles(void) {
   Serial.println();
   Serial.println("Flash FS files found:");
-
-  fs::Dir dir = LittleFS.openDir("/"); // Root directory
   String  line = "=====================================";
 
   Serial.println(line);
   Serial.println("  File name               Size");
   Serial.println(line);
+#ifdef ESP32 // LittleFS is implemented in a different way on ESP32
+  File dir = LittleFS.open("/"); // Root directory
+  File f = dir.openNextFile(); 
+
+  while (f) {
+    String fileName = f.name(); 
+    Serial.print(fileName);
+    int spaces = 25 - fileName.length(); // Tabulate nicely
+    if (spaces < 0) spaces = 1;
+    while (spaces--) Serial.print(" ");
+    Serial.print(f.size()); Serial.println(" bytes"); 
+    f = dir.openNextFile(); 
+    yield();
+  }
+#else
+  fs::Dir dir = LittleFS.openDir("/"); // Root directory
 
   while (dir.next()) {
     String fileName = dir.fileName();
@@ -29,6 +43,7 @@ void listFiles(void) {
     Serial.print(f.size()); Serial.println(" bytes");
     yield();
   }
+ #endif
 
   Serial.println(line);
 

--- a/examples/Test and diagnostics/Test_Touch_Controller/Test_Touch_Controller.ino
+++ b/examples/Test and diagnostics/Test_Touch_Controller/Test_Touch_Controller.ino
@@ -31,15 +31,25 @@ void setup(void) {
 
 void loop() {
 
-  uint16_t x, y;
+  int32_t x, y;
 
   tft.getTouchRaw(&x, &y);
-  
+  #ifndef ARDUINO_XIAO_RA4M1 
   Serial.printf("x: %i     ", x);
 
   Serial.printf("y: %i     ", y);
 
   Serial.printf("z: %i \n", tft.getTouchRawZ());
+  #else
+  Serial.print("x: ");
+  Serial.print(x);
+
+  Serial.print("     y: ");
+  Serial.print(y);
+
+  Serial.print("     z: ");
+  Serial.println(tft.getTouchRawZ());
+  #endif
 
   delay(250);
 


### PR DESCRIPTION
Add necessary dependency libraries in run-cl-arduino.yml

Make example fixes for specific boards

Add examples that cannot be compiled temporarily to ignore.list

Correct included header file names to compile on Linux

Contains necessary header files to compile through certain examples