### PR TITLE
Update Setup504_Seeed_XIAO_EPaper_2inch9.h

### DIFF
--- a/User_Setups/Setup504_Seeed_XIAO_EPaper_2inch9.h
+++ b/User_Setups/Setup504_Seeed_XIAO_EPaper_2inch9.h
@@ -19,7 +19,8 @@
 #define TFT_MOSI D10
 #define TFT_CS D1 // Chip select control pin
 #define TFT_DC D3 // Data Command control pin
-#define TFT_BUSY D2
+#define TFT_BUSY D5
+#define BUSY_ACTIVE_LEVEL LOW
 #define TFT_RST D0 // Reset pin (could connect to RST pin)
 
 #define LOAD_GLCD  // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH


### PR DESCRIPTION
fix incorrect pin assignment from D2 to D5 per the documentation here https://wiki.seeedstudio.com/XIAO-eInk-Expansion-Board/#resources