### PR TITLE
fix: issue with SSD1680 with wrong hardcoded size and compile error

### DIFF
--- a/TFT_Drivers/SSD1680_Defines.h
+++ b/TFT_Drivers/SSD1680_Defines.h
@@ -86,17 +86,17 @@
         writecommand(0x12);                \
         CHECK_BUSY();                      \
         writecommand(0x01);                \
-        writedata((250 - 1) % 256); \
-        writedata((250 - 1) / 256); \
+        writedata((EPD_HEIGHT - 1) % 256); \
+        writedata((EPD_HEIGHT - 1) / 256); \
         writedata(0x00);                   \
         writecommand(0x11);                \
         writedata(0x01);                   \
         writecommand(0x44);                \
         writedata(0x00);                   \
-        writedata(128 / 8 - 1);      \
+        writedata(EPD_WIDTH / 8 - 1);      \
         writecommand(0x45);                \
-        writedata((250 - 1) % 256); \
-        writedata((250 - 1) / 256); \
+        writedata((EPD_HEIGHT - 1) % 256); \
+        writedata((EPD_HEIGHT - 1) / 256); \
         writedata(0x00);                   \
         writedata(0x00);                   \
         writecommand(0x3C);                \
@@ -109,8 +109,8 @@
         writecommand(0x4E);                \
         writedata(0x00);                   \
         writecommand(0x4F);                \
-        writedata((250 - 1) % 256); \
-        writedata((250 - 1) / 256); \
+        writedata((EPD_HEIGHT - 1) % 256); \
+        writedata((EPD_HEIGHT - 1) / 256); \
         CHECK_BUSY();                      \
     } while (0)
 

--- a/TFT_Drivers/SSD1680_Init.h
+++ b/TFT_Drivers/SSD1680_Init.h
@@ -58,7 +58,4 @@
     writedata((128 - 1) % 256);
     writedata((128 - 1) / 256);
     CHECK_BUSY();
-
-    //set ic offset
-    setViewport(COL_OFFSET ,ROW_OFFSET ,EPD_WIDTH - COL_OFFSET ,EPD_HEIGHT - ROW_OFFSET);
 }


### PR DESCRIPTION
There is a compile error for missing definitions of `COL_OFFSET` and `ROW_OFFSET`. 

And the SSD1680 which is 296x128 was incorrectly initialized. 