### PR TITLE
Added 10ms delay after SW reset in EPD_WAKEUP macro in SSD1681_Defines.h

### DIFF
--- a/TFT_Drivers/SSD1681_Defines.h
+++ b/TFT_Drivers/SSD1681_Defines.h
@@ -94,6 +94,7 @@
         digitalWrite(TFT_RST, HIGH); \
         delay(10);                   \
         writecommand(0x12);          \
+        delay(10);    /* mandatory */\
         CHECK_BUSY();                \
     } while (0)
 


### PR DESCRIPTION
The SSD1681 was not updating after the first update, and I narrowed it down to an issue in the EPD_WAKEUP where the "busy" pin wasn't activating immediately after the software reset, thus the code continued before the screen was properly awake. I tried a 1ms delay, and it was insufficient, but 10ms was sufficient to avoid this error with the SSD1681. Confirmed working with XIAO ESP32C6.