### PR TITLE
fix: add missing _grayLevel attribute initializer to EPaper class constructor

### DIFF
--- a/Extensions/EPaper.cpp
+++ b/Extensions/EPaper.cpp
@@ -1,4 +1,4 @@
-EPaper::EPaper() : TFT_eSprite(this), _sleep(true), _entemp(true), _temp(16.00), _humi(50.00)
+EPaper::EPaper() : TFT_eSprite(this), _grayLevel(0), _sleep(true), _entemp(true), _temp(16.00), _humi(50.00)
 {
     setColorDepth(EPD_COLOR_DEPTH);
     createSprite(_width, _height, 1);


### PR DESCRIPTION
I ran into an issue where the `update` method of the EPaper class silently fails if it has not been instantiated as a global object.

#### Example:

This works:
```cpp
EPaper epaper;

void setup() {
  epaper.begin();
  epaper.fillScreen(TFT_BLACK);
  epaper.update();
}
```

`update()` silently fails here:
```cpp

EPaper* epaper = nullptr;

void setup() {
  epaper = new EPaper();

  epaper.begin();
  epaper.fillScreen(TFT_BLACK);
  epaper.update();  
}
```

#### Root Cause:

The `_grayLevel` attribute is not being initialized in the constructor, causing this attribute to have a random value assigned when its initialized as a dynamic object (e.g. inside a method).

The `update` method checks if `_grayLevel` is 0 and otherwise treats the display as a monochrome panel which is a "noop" if the display is actually a color display.